### PR TITLE
Get the Internet Gateway attached to the VPC from AWS as a data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ module "subnets" {
   stage                      = "${var.stage}"
   region                     = "${var.region}"
   vpc_id                     = "${var.vpc_id}"
-  igw_id                     = "${var.igw_id}"
   cidr_block                 = "${var.cidr_block}"
   vpc_default_route_table_id = "${var.vpc_default_route_table_id}"
   public_network_acl_id      = "${var.public_network_acl_id}"
@@ -31,20 +30,19 @@ module "subnets" {
 
 ## Variables
 
-|  Name                        |  Default       |  Description                                                                                                                         | Required |
-|:----------------------------:|:--------------:|:------------------------------------------------------------------------------------------------------------------------------------:|:--------:|
-| namespace                    | ``             | Namespace (e.g. `cp` or `cloudposse`)                                                                                                | Yes      |
-| stage                        | ``             | Stage (e.g. `prod`, `dev`, `staging`)                                                                                                | Yes      |
-| name                         | ``             | Name  (e.g. `bastion` or `db`)                                                                                                       | Yes      |
-| tags                         | ``             | Additional tags (e.g. `Key, Value`)                                                                                                  | No       |
-| region                       | ``             | AWS Region where module should operate (e.g. `us-east-1`)                                                                            | Yes      |
-| vpc_id                       | ``             | The VPC ID where subnets will be created (e.g. `vpc-aceb2723`)                                                                       | Yes      |
-| cidr_block                   | ``             | The base CIDR block which will be divided into subnet CIDR blocks (e.g. `10.0.0.0/16`)                                               | Yes      |
-| igw_id                       | ``             | The Internet Gateway ID public route table will point to (e.g. `igw-9c26a123`)                                                       | Yes      |
-| vpc_default_route_table_id   | ``             | The default route table for public subnets. Provides access to the Internet. If not set here, will be created. (e.g. `rtb-f4f0ce12`) | No       |
-| availability_zones           | []             | The list of Availability Zones where subnets will be created (e.g. `["us-eas-1a", "us-eas-1b"]`)                                     | Yes      |
-| public_network_acl_id        | ``             | Network ACL ID that will be added to public subnets.  If empty, a new ACL will be created                                            | No       |
-| private_network_acl_id       | ``             | Network ACL ID that will be added to private subnets.  If empty, a new ACL will be created                                           | No       |
+|  Name                        |  Default       |  Description                                                                                                                           | Required |
+|:-----------------------------|:--------------:|:---------------------------------------------------------------------------------------------------------------------------------------|:--------:|
+| namespace                    | ``             | Namespace (e.g. `cp` or `cloudposse`)                                                                                                  | Yes      |
+| stage                        | ``             | Stage (e.g. `prod`, `dev`, `staging`)                                                                                                  | Yes      |
+| name                         | ``             | Name  (e.g. `bastion` or `db`)                                                                                                         | Yes      |
+| tags                         | ``             | Additional tags (e.g. `Key, Value`)                                                                                                    | No       |
+| region                       | ``             | AWS Region where module should operate (e.g. `us-east-1`)                                                                              | Yes      |
+| vpc_id                       | ``             | The VPC ID where subnets will be created (e.g. `vpc-aceb2723`)                                                                         | Yes      |
+| cidr_block                   | ``             | The base CIDR block which will be divided into subnet CIDR blocks (e.g. `10.0.0.0/16`)                                                 | Yes      |
+| vpc_default_route_table_id   | ``             | The default route table for public subnets. Provides access to the Internet. If not set here, will be created. (_e.g._ `rtb-f4f0ce12`) | No       |
+| availability_zones           | []             | The list of Availability Zones where subnets will be created (e.g. `["us-eas-1a", "us-eas-1b"]`)                                       | Yes      |
+| public_network_acl_id        | ``             | Network ACL ID that will be added to public subnets.  If empty, a new ACL will be created                                              | No       |
+| private_network_acl_id       | ``             | Network ACL ID that will be added to private subnets.  If empty, a new ACL will be created                                             | No       |
 
 ## TL;DR
 

--- a/main.tf
+++ b/main.tf
@@ -12,3 +12,13 @@ data "aws_vpc" "default" {
 }
 
 data "aws_availability_zones" "available" {}
+
+# Get the Internet Gateway attached to the VPC
+# https://www.terraform.io/docs/providers/aws/d/internet_gateway.html
+# https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInternetGateways.html
+data "aws_internet_gateway" "default" {
+  filter {
+    name   = "attachment.vpc-id"
+    values = ["${var.vpc_id}"]
+  }
+}

--- a/public.tf
+++ b/public.tf
@@ -34,7 +34,7 @@ resource "aws_route_table" "public" {
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${var.igw_id}"
+    gateway_id = "${data.aws_internet_gateway.default.id}"
   }
 
   tags = "${module.public_label.tags}"

--- a/variables.tf
+++ b/variables.tf
@@ -39,5 +39,3 @@ variable "public_network_acl_id" {
 variable "private_network_acl_id" {
   default = ""
 }
-
-variable "igw_id" {}


### PR DESCRIPTION
## What

* Get the Internet Gateway attached to the VPC from AWS

## Why

* Since only one `Internet Gateway` could be attached to a VPC (and we suppose it's already attached since we use its ID), we can get the ID from AWS instead of manually defining it in `variables.tf`

* The users of the module do not have to provide the `Internet Gateway` ID for the `VPC`

## References

* https://www.terraform.io/docs/providers/aws/d/internet_gateway.html
* https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInternetGateways.html

