### PR TITLE
Changed required version syntax

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.10.2"
+  required_version = ">= 0.10.2"
 }
 
 provider "aws" {


### PR DESCRIPTION
## what

* Losen version constraint

## why
*  This is the change in required version syntax in order to be able to work with the Terraform Jenkins module
* it is related to the issue [https://github.com/cloudposse/terraform-aws-jenkins/issues/11](https://github.com/cloudposse/terraform-aws-jenkins/issues/11).
  