### PR TITLE
Remove `provider "aws"`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 Cloud Posse, LLC
+   Copyright 2017-2018 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/main.tf
+++ b/main.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 0.10.2"
 }
 
-provider "aws" {
-  region = "${var.region}"
-}
-
 # Get object aws_vpc by vpc_id
 data "aws_vpc" "default" {
   id = "${var.vpc_id}"


### PR DESCRIPTION
## what
* Removed `provider "aws"`

## why
* Not necessary here, should be used in higher-level modules
* Prevents inheriting provider settings from higher-level modules
* Becomes an issue when testing locally if we use the AWS security keys like this (not the best practice, but people use it for testing):

```hcl
provider "aws" {
  region     = "${var.region}"
  access_key = "XXXXXXXXXXXXX"
  secret_key = "XXXXXXXXXXXXX"
}
```

At the same time, this code in `terraform-aws-dynamic-subnets`:
```hcl
provider "aws" {
  region = "${var.region}"
}
```
throws the error:
 `module.subnets.provider.aws: No valid credential sources found for AWS Provider`.
