### PR TITLE
Make module more idempotent when working with peering connections, fixes #30

### DIFF
--- a/private.tf
+++ b/private.tf
@@ -38,6 +38,12 @@ resource "aws_route_table" "private" {
   vpc_id = "${data.aws_vpc.default.id}"
 
   tags = "${module.private_label.tags}"
+
+  lifecycle = {
+    ignore_changes = [
+      "route"
+    ]
+  }
 }
 
 resource "aws_route_table_association" "private" {

--- a/private.tf
+++ b/private.tf
@@ -41,7 +41,7 @@ resource "aws_route_table" "private" {
 
   lifecycle = {
     ignore_changes = [
-      "route"
+      "route",
     ]
   }
 }

--- a/public.tf
+++ b/public.tf
@@ -46,7 +46,7 @@ resource "aws_route_table" "public" {
 
   lifecycle = {
     ignore_changes = [
-      "route"
+      "route",
     ]
   }
 }

--- a/public.tf
+++ b/public.tf
@@ -43,6 +43,12 @@ resource "aws_route_table" "public" {
   }
 
   tags = "${module.public_label.tags}"
+
+  lifecycle = {
+    ignore_changes = [
+      "route"
+    ]
+  }
 }
 
 resource "aws_route_table_association" "public" {


### PR DESCRIPTION
This PR prevents module to wipe peering connection out when applying it to existing infrastructure.

It just ignores changes for whole `route` part.

Sadly, it looks like we can't state `ignore_changes` more precisely:
https://github.com/terraform-providers/terraform-provider-aws/issues/3819