### PR TITLE
Changed the private subnet code to use var.name instead of the hardco…

### DIFF
--- a/private.tf
+++ b/private.tf
@@ -12,7 +12,7 @@ module "private_subnet_label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
-  name       = "subnet"
+  name       = "${var.name}"
   attributes = ["private"]
   tags       = "${var.tags}"
 }


### PR DESCRIPTION
…ded 'subnet'

## what
* In private.tf, changed `private_subnet_label` so that `name  = "subnet"` is now `name = "${var.name}"`

## why
* Fix bug #39 to make the private and public subnet names consistent
