### PR TITLE
Include attributes in names

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,10 @@ Available targets:
 | Name | Description |
 |------|-------------|
 | private_route_table_ids | - |
+| private_subnet_cidrs | - |
 | private_subnet_ids | - |
 | public_route_table_ids | - |
+| public_subnet_cidrs | - |
 | public_subnet_ids | - |
 
 

--- a/README.md
+++ b/README.md
@@ -172,12 +172,12 @@ Available targets:
 
 | Name | Description |
 |------|-------------|
-| private_route_table_ids | - |
-| private_subnet_cidrs | - |
-| private_subnet_ids | - |
-| public_route_table_ids | - |
-| public_subnet_cidrs | - |
-| public_subnet_ids | - |
+| private_route_table_ids | AWS ID of the created private route table |
+| private_subnet_cidrs | CIDR of the created private subnet |
+| private_subnet_ids | AWS ID of the created private subnet |
+| public_route_table_ids | AWS ID of the created public route table |
+| public_subnet_cidrs | CIDR of the created public subnet |
+| public_subnet_ids | AWS ID of the created public subnet |
 
 
 

--- a/README.md
+++ b/README.md
@@ -172,12 +172,12 @@ Available targets:
 
 | Name | Description |
 |------|-------------|
-| private_route_table_ids | AWS ID of the created private route table |
-| private_subnet_cidrs | CIDR of the created private subnet |
-| private_subnet_ids | AWS ID of the created private subnet |
-| public_route_table_ids | AWS ID of the created public route table |
-| public_subnet_cidrs | CIDR of the created public subnet |
-| public_subnet_ids | AWS ID of the created public subnet |
+| private_route_table_ids | AWS IDs of the created private route tables |
+| private_subnet_cidrs | CIDR blocks of the created private subnets |
+| private_subnet_ids | AWS IDs of the created private subnets |
+| public_route_table_ids | AWS IDs of the created public route tables |
+| public_subnet_cidrs | CIDR blocks of the created public subnets |
+| public_subnet_ids | AWS IDs of the created public subnets |
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -25,7 +25,9 @@
 | Name | Description |
 |------|-------------|
 | private_route_table_ids | - |
+| private_subnet_cidrs | - |
 | private_subnet_ids | - |
 | public_route_table_ids | - |
+| public_subnet_cidrs | - |
 | public_subnet_ids | - |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -24,10 +24,10 @@
 
 | Name | Description |
 |------|-------------|
-| private_route_table_ids | AWS ID of the created private route table |
-| private_subnet_cidrs | CIDR of the created private subnet |
-| private_subnet_ids | AWS ID of the created private subnet |
-| public_route_table_ids | AWS ID of the created public route table |
-| public_subnet_cidrs | CIDR of the created public subnet |
-| public_subnet_ids | AWS ID of the created public subnet |
+| private_route_table_ids | AWS IDs of the created private route tables |
+| private_subnet_cidrs | CIDR blocks of the created private subnets |
+| private_subnet_ids | AWS IDs of the created private subnets |
+| public_route_table_ids | AWS IDs of the created public route tables |
+| public_subnet_cidrs | CIDR blocks of the created public subnets |
+| public_subnet_ids | AWS IDs of the created public subnets |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -24,10 +24,10 @@
 
 | Name | Description |
 |------|-------------|
-| private_route_table_ids | - |
-| private_subnet_cidrs | - |
-| private_subnet_ids | - |
-| public_route_table_ids | - |
-| public_subnet_cidrs | - |
-| public_subnet_ids | - |
+| private_route_table_ids | AWS ID of the created private route table |
+| private_subnet_cidrs | CIDR of the created private subnet |
+| private_subnet_ids | AWS ID of the created private subnet |
+| public_route_table_ids | AWS ID of the created public route table |
+| public_subnet_cidrs | CIDR of the created public subnet |
+| public_subnet_ids | AWS ID of the created public subnet |
 

--- a/nat.tf
+++ b/nat.tf
@@ -4,7 +4,7 @@ module "nat_label" {
   stage      = "${var.stage}"
   name       = "${var.name}"
   delimiter  = "${var.delimiter}"
-  attributes = "${concat(var.attributes,list("nat"))}"
+  attributes = "${compact(concat(var.attributes,list("nat")))}"
   tags       = "${var.tags}"
 }
 

--- a/nat.tf
+++ b/nat.tf
@@ -1,10 +1,11 @@
 module "nat_label" {
-  source    = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
-  namespace = "${var.namespace}"
-  stage     = "${var.stage}"
-  name      = "${var.name}"
-  delimiter = "${var.delimiter}"
-  tags      = "${var.tags}"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.name}"
+  delimiter  = "${var.delimiter}"
+  attributes = "${concat(var.attributes,list("nat"))}"
+  tags       = "${var.tags}"
 }
 
 locals {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,23 +1,29 @@
 output "public_subnet_ids" {
-  value = ["${aws_subnet.public.*.id}"]
+  description = "AWS ID of the created public subnet"
+  value       = ["${aws_subnet.public.*.id}"]
 }
 
 output "private_subnet_ids" {
-  value = ["${aws_subnet.private.*.id}"]
+  description = "AWS ID of the created private subnet"
+  value       = ["${aws_subnet.private.*.id}"]
 }
 
 output "public_subnet_cidrs" {
-  value = ["${aws_subnet.public.*.cidr_block}"]
+  description = "CIDR of the created public subnet"
+  value       = ["${aws_subnet.public.*.cidr_block}"]
 }
 
 output "private_subnet_cidrs" {
-  value = ["${aws_subnet.private.*.cidr_block}"]
+  description = "CIDR of the created private subnet"
+  value       = ["${aws_subnet.private.*.cidr_block}"]
 }
 
 output "public_route_table_ids" {
-  value = ["${aws_route_table.public.*.id}"]
+  description = "AWS ID of the created public route table"
+  value       = ["${aws_route_table.public.*.id}"]
 }
 
 output "private_route_table_ids" {
-  value = ["${aws_route_table.private.*.id}"]
+  description = "AWS ID of the created private route table"
+  value       = ["${aws_route_table.private.*.id}"]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,6 +6,14 @@ output "private_subnet_ids" {
   value = ["${aws_subnet.private.*.id}"]
 }
 
+output "public_subnet_cidrs" {
+  value = ["${aws_subnet.public.*.cidr_block}"]
+}
+
+output "private_subnet_cidrs" {
+  value = ["${aws_subnet.private.*.cidr_block}"]
+}
+
 output "public_route_table_ids" {
   value = ["${aws_route_table.public.*.id}"]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,29 +1,29 @@
 output "public_subnet_ids" {
-  description = "AWS ID of the created public subnet"
+  description = "AWS IDs of the created public subnets"
   value       = ["${aws_subnet.public.*.id}"]
 }
 
 output "private_subnet_ids" {
-  description = "AWS ID of the created private subnet"
+  description = "AWS IDs of the created private subnets"
   value       = ["${aws_subnet.private.*.id}"]
 }
 
 output "public_subnet_cidrs" {
-  description = "CIDR of the created public subnet"
+  description = "CIDR blocks of the created public subnets"
   value       = ["${aws_subnet.public.*.cidr_block}"]
 }
 
 output "private_subnet_cidrs" {
-  description = "CIDR of the created private subnet"
+  description = "CIDR blocks of the created private subnets"
   value       = ["${aws_subnet.private.*.cidr_block}"]
 }
 
 output "public_route_table_ids" {
-  description = "AWS ID of the created public route table"
+  description = "AWS IDs of the created public route tables"
   value       = ["${aws_route_table.public.*.id}"]
 }
 
 output "private_route_table_ids" {
-  description = "AWS ID of the created private route table"
+  description = "AWS IDs of the created private route tables"
   value       = ["${aws_route_table.private.*.id}"]
 }

--- a/private.tf
+++ b/private.tf
@@ -4,7 +4,7 @@ module "private_label" {
   stage      = "${var.stage}"
   name       = "${var.name}"
   delimiter  = "${var.delimiter}"
-  attributes = ["private"]
+  attributes = "${concat(var.attributes,list("private"))}"
   tags       = "${var.tags}"
 }
 
@@ -13,7 +13,7 @@ module "private_subnet_label" {
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"
-  attributes = ["private"]
+  attributes = "${concat(var.attributes,list("private"))}"
   tags       = "${var.tags}"
 }
 

--- a/private.tf
+++ b/private.tf
@@ -4,7 +4,7 @@ module "private_label" {
   stage      = "${var.stage}"
   name       = "${var.name}"
   delimiter  = "${var.delimiter}"
-  attributes = "${concat(var.attributes,list("private"))}"
+  attributes = "${compact(concat(var.attributes,list("private")))}"
   tags       = "${var.tags}"
 }
 
@@ -13,7 +13,7 @@ module "private_subnet_label" {
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"
-  attributes = "${concat(var.attributes,list("private"))}"
+  attributes = "${compact(concat(var.attributes,list("private")))}"
   tags       = "${var.tags}"
 }
 

--- a/public.tf
+++ b/public.tf
@@ -4,7 +4,7 @@ module "public_label" {
   stage      = "${var.stage}"
   name       = "${var.name}"
   delimiter  = "${var.delimiter}"
-  attributes = ["public"]
+  attributes = "${concat(var.attributes,list("public"))}"
   tags       = "${var.tags}"
 }
 
@@ -13,7 +13,7 @@ module "public_subnet_label" {
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"
-  attributes = ["public"]
+  attributes = "${concat(var.attributes,list("public"))}"
   tags       = "${var.tags}"
 }
 

--- a/public.tf
+++ b/public.tf
@@ -4,7 +4,7 @@ module "public_label" {
   stage      = "${var.stage}"
   name       = "${var.name}"
   delimiter  = "${var.delimiter}"
-  attributes = "${concat(var.attributes,list("public"))}"
+  attributes = "${compact(concat(var.attributes,list("public")))}"
   tags       = "${var.tags}"
 }
 
@@ -13,7 +13,7 @@ module "public_subnet_label" {
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"
-  attributes = "${concat(var.attributes,list("public"))}"
+  attributes = "${compact(concat(var.attributes,list("public")))}"
   tags       = "${var.tags}"
 }
 


### PR DESCRIPTION
## what
Include attributes in names of created resources. Given 
```
module "subnets" {
  source              = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=master"
  namespace           = "cp"
  stage               = "prod"
  name                = "app"
  region              = "us-east-1"
  vpc_id              = "vpc-XXXXXXXX"
  igw_id              = "igw-XXXXXXXX"
  cidr_block          = "10.0.0.0/16"
  availability_zones  = ["us-east-1a", "us-east-1b"]
  attributes          = ["common"]
}
```
You will now get subnet labels like `cp-prod-app-common-public-us-east-1b`

## why
More specific names are needed when using multiple subnets in a single environment.