### PR TITLE
Include Availability Zone name in resources that are 1 per AZ

### DIFF
--- a/nat.tf
+++ b/nat.tf
@@ -15,7 +15,7 @@ locals {
 resource "aws_eip" "default" {
   count = "${local.nat_gateways_count}"
   vpc   = true
-  tags  = "${module.private_label.tags}"
+  tags  = "${merge(module.private_label.tags, map("Name",format("%s%s%s", module.private_label.id, var.delimiter, replace(element(var.availability_zones, count.index),"-",var.delimiter))))}"
 
   lifecycle {
     create_before_destroy = true
@@ -26,7 +26,7 @@ resource "aws_nat_gateway" "default" {
   count         = "${local.nat_gateways_count}"
   allocation_id = "${element(aws_eip.default.*.id, count.index)}"
   subnet_id     = "${element(aws_subnet.public.*.id, count.index)}"
-  tags          = "${module.nat_label.tags}"
+  tags  = "${merge(module.nat_label.tags, map("Name",format("%s%s%s", module.nat_label.id, var.delimiter, replace(element(var.availability_zones, count.index),"-",var.delimiter))))}"
 
   lifecycle {
     create_before_destroy = true

--- a/nat.tf
+++ b/nat.tf
@@ -26,7 +26,7 @@ resource "aws_nat_gateway" "default" {
   count         = "${local.nat_gateways_count}"
   allocation_id = "${element(aws_eip.default.*.id, count.index)}"
   subnet_id     = "${element(aws_subnet.public.*.id, count.index)}"
-  tags  = "${merge(module.nat_label.tags, map("Name",format("%s%s%s", module.nat_label.id, var.delimiter, replace(element(var.availability_zones, count.index),"-",var.delimiter))))}"
+  tags          = "${merge(module.nat_label.tags, map("Name",format("%s%s%s", module.nat_label.id, var.delimiter, replace(element(var.availability_zones, count.index),"-",var.delimiter))))}"
 
   lifecycle {
     create_before_destroy = true

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,3 +27,13 @@ output "private_route_table_ids" {
   description = "AWS IDs of the created private route tables"
   value       = ["${aws_route_table.private.*.id}"]
 }
+
+output "nat_gateway_ids" {
+  description = "AWS IDs of the NAT gateways created"
+  value = ["${aws_nat_gateway.default.*.id}"]
+}
+
+output "availability_zones" {
+ description = "List of Availability Zones where subnets were created"
+  value = "${var.availability_zones}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,10 +30,10 @@ output "private_route_table_ids" {
 
 output "nat_gateway_ids" {
   description = "AWS IDs of the NAT gateways created"
-  value = ["${aws_nat_gateway.default.*.id}"]
+  value       = ["${aws_nat_gateway.default.*.id}"]
 }
 
 output "availability_zones" {
- description = "List of Availability Zones where subnets were created"
-  value = "${var.availability_zones}"
+  description = "List of Availability Zones where subnets were created"
+  value       = "${var.availability_zones}"
 }

--- a/private.tf
+++ b/private.tf
@@ -28,13 +28,18 @@ resource "aws_subnet" "private" {
   cidr_block        = "${cidrsubnet(signum(length(var.cidr_block)) == 1 ? var.cidr_block : data.aws_vpc.default.cidr_block, ceil(log(local.private_subnet_count * 2, 2)), count.index)}"
 
   tags = "${merge(module.private_subnet_label.tags, map("Name",format("%s%s%s", module.private_subnet_label.id, var.delimiter, replace(element(var.availability_zones, count.index),"-",var.delimiter))))}"
+
+  lifecycle {
+    # Ignore tags added by kops or kubernetes
+    ignore_changes = ["tags.%", "tags.kubernetes", "tags.SubnetType"]
+  }
 }
 
 resource "aws_route_table" "private" {
   count  = "${length(var.availability_zones)}"
   vpc_id = "${data.aws_vpc.default.id}"
 
-  tags = "${module.private_label.tags}"
+  tags = "${merge(module.private_subnet_label.tags, map("Name",format("%s%s%s", module.private_subnet_label.id, var.delimiter, replace(element(var.availability_zones, count.index),"-",var.delimiter))))}"
 }
 
 resource "aws_route_table_association" "private" {

--- a/public.tf
+++ b/public.tf
@@ -29,6 +29,11 @@ resource "aws_subnet" "public" {
   cidr_block              = "${cidrsubnet(signum(length(var.cidr_block)) == 1 ? var.cidr_block : data.aws_vpc.default.cidr_block, ceil(log(local.public_subnet_count * 2, 2)), local.public_subnet_count + count.index)}"
   map_public_ip_on_launch = "${local.map_public_ip_on_launch}"
   tags                    = "${merge(module.public_subnet_label.tags, map("Name",format("%s%s%s", module.public_subnet_label.id, var.delimiter, replace(element(var.availability_zones, count.index),"-",var.delimiter))))}"
+
+  lifecycle {
+    # Ignore tags added by kops or kubernetes
+    ignore_changes = ["tags.%", "tags.kubernetes", "tags.SubnetType"]
+  }
 }
 
 resource "aws_route_table" "public" {


### PR DESCRIPTION
## what
- Include Availability Zone name in resources that are 1 per Availability Zone
- Ignore AWS tags created by `kops` and `kubernetes`

## why
- Make it easy to determine which resources are in which availability zone
- Prevent Terraform from removing tags that `kops` and `kubernetes` use to manage resources