### PR TITLE
Fixes 36

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 ## Usage
 
+
+**IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases.
+Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-dynamic-subnets/releases).
+
+
 ```hcl
 module "subnets" {
   source              = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=master"
@@ -165,6 +170,7 @@ Available targets:
 | region | AWS Region (e.g. `us-east-1`) | string | - | yes |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
 | subnet_type_tag_key | Key for subnet type tag to provide information about the type of subnets, e.g. `cpco.io/subnet/type=private` or `cpco.io/subnet/type=public` | string | `cpco.io/subnet/type` | no |
+| subnet_type_tag_value_format | This is using the format interpolation symbols to allow the value of the subnet_type_tag_key to be modified. | string | `%s` | no |
 | tags | Additional tags (e.g. map(`Cluster`,`XYZ`) | map | `<map>` | no |
 | vpc_default_route_table_id | Default route table for public subnets. If not set, will be created. (e.g. `rtb-f4f0ce12`) | string | `` | no |
 | vpc_id | VPC ID where subnets will be created (e.g. `vpc-aceb2723`) | string | - | yes |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -17,6 +17,7 @@
 | region | AWS Region (e.g. `us-east-1`) | string | - | yes |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
 | subnet_type_tag_key | Key for subnet type tag to provide information about the type of subnets, e.g. `cpco.io/subnet/type=private` or `cpco.io/subnet/type=public` | string | `cpco.io/subnet/type` | no |
+| subnet_type_tag_value_format | This is using the format interpolation symbols to allow the value of the subnet_type_tag_key to be modified. | string | `%s` | no |
 | tags | Additional tags (e.g. map(`Cluster`,`XYZ`) | map | `<map>` | no |
 | vpc_default_route_table_id | Default route table for public subnets. If not set, will be created. (e.g. `rtb-f4f0ce12`) | string | `` | no |
 | vpc_id | VPC ID where subnets will be created (e.g. `vpc-aceb2723`) | string | - | yes |

--- a/private.tf
+++ b/private.tf
@@ -5,7 +5,7 @@ module "private_label" {
   name       = "${var.name}"
   delimiter  = "${var.delimiter}"
   attributes = "${compact(concat(var.attributes,list("private")))}"
-  tags       = "${merge(var.tags, map(var.subnet_type_tag_key, "private"))}"
+  tags       = "${merge(var.tags, map(var.subnet_type_tag_key, format(var.subnet_type_tag_value_format,"private")))}"
 }
 
 module "private_subnet_label" {
@@ -14,7 +14,7 @@ module "private_subnet_label" {
   stage      = "${var.stage}"
   name       = "${var.name}"
   attributes = "${compact(concat(var.attributes,list("private")))}"
-  tags       = "${merge(var.tags, map(var.subnet_type_tag_key, "private"))}"
+  tags       = "${merge(var.tags, map(var.subnet_type_tag_key, format(var.subnet_type_tag_value_format,"private")))}"
 }
 
 locals {

--- a/public.tf
+++ b/public.tf
@@ -5,7 +5,7 @@ module "public_label" {
   name       = "${var.name}"
   delimiter  = "${var.delimiter}"
   attributes = "${compact(concat(var.attributes,list("public")))}"
-  tags       = "${merge(var.tags, map(var.subnet_type_tag_key, "public"))}"
+  tags       = "${merge(var.tags, map(var.subnet_type_tag_key, format(var.subnet_type_tag_value_format,"public")))}"
 }
 
 module "public_subnet_label" {
@@ -14,7 +14,7 @@ module "public_subnet_label" {
   stage      = "${var.stage}"
   name       = "${var.name}"
   attributes = "${compact(concat(var.attributes,list("public")))}"
-  tags       = "${merge(var.tags, map(var.subnet_type_tag_key, "public"))}"
+  tags       = "${merge(var.tags, map(var.subnet_type_tag_key, format(var.subnet_type_tag_value_format,"public")))}"
 }
 
 locals {

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,7 @@ variable "subnet_type_tag_key" {
   default     = "cpco.io/subnet/type"
   description = "Key for subnet type tag to provide information about the type of subnets, e.g. `cpco.io/subnet/type=private` or `cpco.io/subnet/type=public`"
 }
+
 variable "subnet_type_tag_value_format" {
   default     = "%s"
   description = "This is using the format interpolation symbols to allow the value of the subnet_type_tag_key to be modified."

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,11 @@ variable "subnet_type_tag_key" {
   default     = "cpco.io/subnet/type"
   description = "Key for subnet type tag to provide information about the type of subnets, e.g. `cpco.io/subnet/type=private` or `cpco.io/subnet/type=public`"
 }
+variable "subnet_type_tag_value_format" {
+  default     = "%s"
+  description = "This is using the format interpolation symbols to allow the value of the subnet_type_tag_key to be modified."
+  type        = "string"
+}
 
 variable "region" {
   type        = "string"


### PR DESCRIPTION
## what
- Added a working example. 
- Added the ability to specify the number of public or private subnets. 
- Added the ability to specify the format of the public/private subnet tag. 
- Updated the label module to allow the use of context. 
- Updated the default `cidr_range` to allow for a default value so it automatically can pull it from the vpc

## why
- Fixes #36
- Also allows users to use the module to create just a public OR a private subnet, or have different numbers of each.


## example

i.e:
```hcl
module "dynamic_subnets" {
  source                  = "./.."
  context                 = "${module.label.context}"
  tags                    = "${merge(module.label.tags, local.subnet_tags)}"
  region                  = "${data.aws_region.current.name}"
  availability_zones      = ["${data.aws_region.current.name}a", "${data.aws_region.current.name}b"] // Optional list of AZ's to restrict it to
  vpc_id                  = "${module.vpc.vpc_id}"
  igw_id                  = "${module.vpc.igw_id}"
  public_subnet_count     = "2"                                                                      // Two public zones for the load balancers
  private_subnet_count    = "4"                                                                      // Four private zones for the 
}
```