### PR TITLE
removed provider configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,9 @@
 # Pin the `aws` provider
 # https://www.terraform.io/docs/configuration/providers.html
 # Any non-beta version >= 2.12.0 and < 2.13.0, e.g. 2.12.X
-provider "aws" {
-  version = "~> 2.12.0"
-}
+# provider "aws" {
+#   version = "~> 2.12.0"
+# }
 
 # Terraform
 #--------------------------------------------------------------

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,3 @@
-# Pin the `aws` provider
-# https://www.terraform.io/docs/configuration/providers.html
-# Any non-beta version >= 2.12.0 and < 2.13.0, e.g. 2.12.X
-# provider "aws" {
-#   version = "~> 2.12.0"
-# }
-
 # Terraform
 #--------------------------------------------------------------
 terraform {


### PR DESCRIPTION
## what
removed provider block

## why

While using this module a `terrform plan` always requested to specify the region, although the variable `region` is set in the module.

```
provider "aws" {
  assume_role {
    role_arn = "${var.aws_assume_role_arn}"
  }

  region = "${var.region}"
}

module "subnets" {
  source              = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.11.0"
  availability_zones  = ["${data.aws_availability_zones.available.names}"]
  namespace           = "${var.namespace}"
  stage               = "${var.stage}"
  name                = "${var.name}"
  attributes          = "${var.attributes}"
  tags                = "${local.tags}"
  region              = "${var.region}"
  vpc_id              = "${module.vpc.vpc_id}"
  igw_id              = "${module.vpc.igw_id}"
  cidr_block          = "${module.vpc.vpc_cidr_block}"
  nat_gateway_enabled = "true"
}
``` 

```
>terraform plan
provider.aws.region
  The region where AWS operations will take place. Examples
  are us-east-1, us-west-2, etc.

  Default: us-east-1
  Enter a value: 
```
