### PR TITLE
Revert "Fix regressions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Available targets:
 | public_network_acl_id | Network ACL ID that will be added to public subnets. If empty, a new ACL will be created | string | `` | no |
 | public_subnet_count | Sets the amount of public subnets to deploy.  -1 will deploy a subnet for every availablility zone within the region, 0 will deploy no subnets. The AZ's supplied will be cycled through to create the subnets | string | `-1` | no |
 | regex_replace_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only hyphens, letters and digits are allowed, all other chars are removed | string | `/[^a-zA-Z0-9-]/` | no |
+| region | The region to pass to the AWS provider nested in this module. | string | - | yes |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | `` | no |
 | subnet_type_tag_key | Key for subnet type tag to provide information about the type of subnets, e.g. `cpco.io/subnet/type=private` or `cpco.io/subnet/type=public` | string | `cpco.io/subnet/type` | no |
 | subnet_type_tag_value_format | This is using the format interpolation symbols to allow the value of the subnet_type_tag_key to be modified. | string | `%s` | no |

--- a/README.yaml
+++ b/README.yaml
@@ -112,3 +112,4 @@ contributors:
     github: "osulli"
   - name: "dcowan-vestmark"
     github: "dcowan-vestmark"
+

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -23,6 +23,7 @@
 | public_network_acl_id | Network ACL ID that will be added to public subnets. If empty, a new ACL will be created | string | `` | no |
 | public_subnet_count | Sets the amount of public subnets to deploy.  -1 will deploy a subnet for every availablility zone within the region, 0 will deploy no subnets. The AZ's supplied will be cycled through to create the subnets | string | `-1` | no |
 | regex_replace_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only hyphens, letters and digits are allowed, all other chars are removed | string | `/[^a-zA-Z0-9-]/` | no |
+| region | The region to pass to the AWS provider nested in this module. | string | - | yes |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | `` | no |
 | subnet_type_tag_key | Key for subnet type tag to provide information about the type of subnets, e.g. `cpco.io/subnet/type=private` or `cpco.io/subnet/type=public` | string | `cpco.io/subnet/type` | no |
 | subnet_type_tag_value_format | This is using the format interpolation symbols to allow the value of the subnet_type_tag_key to be modified. | string | `%s` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,5 +1,5 @@
 module "vpc" {
-  source = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.4.1"
+  source = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.3.4"
 
   providers = {
     aws = "aws"

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,7 @@
 # Any non-beta version >= 2.12.0 and < 2.13.0, e.g. 2.12.X
 provider "aws" {
   version = "~> 2.12.0"
+  region  = "${var.region}"
 }
 
 # Terraform

--- a/variables.tf
+++ b/variables.tf
@@ -84,3 +84,8 @@ variable "map_public_ip_on_launch" {
   default     = "true"
   description = "Instances launched into a public subnet should be assigned a public IP address"
 }
+
+variable "region" {
+  type        = "string"
+  description = "The region to pass to the AWS provider nested in this module."
+}


### PR DESCRIPTION
Reverts cloudposse/terraform-aws-dynamic-subnets#59

## why
* We need to revert number #54 as it doesn't work reliably 