### PR TITLE
Use `required_providers` to pin Terraform providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,6 @@ Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest re
 ```hcl
 module "subnets" {
   source              = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=master"
-  providers           = {
-    aws = "aws"
-  }
   namespace           = "eg"
   stage               = "prod"
   name                = "app"

--- a/README.yaml
+++ b/README.yaml
@@ -72,9 +72,6 @@ usage: |-
   ```hcl
   module "subnets" {
     source              = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=master"
-    providers           = {
-      aws = "aws"
-    }
     namespace           = "eg"
     stage               = "prod"
     name                = "app"

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = "~> 0.12.0"
 }
 
-# Pin the `aws` provider
-# https://www.terraform.io/docs/configuration/providers.html
-# Any non-beta version >= 2.0.0 and < 3.0.0, e.g. 2.X.Y
 provider "aws" {
-  version = "~> 2.0"
-  region  = var.region
+  region = var.region
 }

--- a/label.tf
+++ b/label.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source              = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.13.0"
+  source              = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.0"
   attributes          = var.attributes
   namespace           = var.namespace
   environment         = var.environment

--- a/nat-gateway.tf
+++ b/nat-gateway.tf
@@ -1,5 +1,5 @@
 module "nat_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.13.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.0"
   context    = module.label.context
   attributes = distinct(compact(concat(module.label.attributes, ["nat"])))
 }

--- a/nat-instance.tf
+++ b/nat-instance.tf
@@ -1,5 +1,5 @@
 module "nat_instance_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.13.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.0"
   context    = module.label.context
   attributes = distinct(compact(concat(module.label.attributes, ["nat", "instance"])))
 }

--- a/private.tf
+++ b/private.tf
@@ -1,5 +1,5 @@
 module "private_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.13.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.0"
   context    = module.label.context
   attributes = compact(concat(module.label.attributes, ["private"]))
 

--- a/public.tf
+++ b/public.tf
@@ -1,5 +1,5 @@
 module "public_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.13.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.0"
   context    = module.label.context
   attributes = compact(concat(module.label.attributes, ["public"]))
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
   required_version = "~> 0.12.0"
-}
 
-# Pin the `aws` provider
-# https://www.terraform.io/docs/configuration/providers.html
-# Any non-beta version >= 2.0.0 and < 3.0.0, e.g. 2.X.Y
-provider "aws" {
-  version = "~> 2.0"
+  required_providers {
+    aws      = "~> 2.0"
+    template = "~> 2.0"
+    local    = "~> 1.2"
+    null     = "~> 2.0"
+  }
 }


### PR DESCRIPTION
## what
* Use `required_providers` to pin Terraform providers

## why
* Pinning the module's providers version in `required_providers` block allows specifying only the required provider version for the module without the need to specify all providers with versions explicitly
