### PR TITLE
add private/public_subnets_tags

### DIFF
--- a/private.tf
+++ b/private.tf
@@ -37,7 +37,8 @@ resource "aws_subnet" "private" {
           var.delimiter
         )
       )
-    }
+    },
+    var.private_subnets_tags,
   )
 
   lifecycle {

--- a/public.tf
+++ b/public.tf
@@ -39,7 +39,8 @@ resource "aws_subnet" "public" {
           var.delimiter
         )
       )
-    }
+    },
+    var.public_subnets_tags,
   )
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -76,3 +76,15 @@ variable "map_public_ip_on_launch" {
   default     = true
   description = "Instances launched into a public subnet should be assigned a public IP address"
 }
+
+variable "private_subnets_tags" {
+  type = map
+  default = {}
+  description = "Tags to apply to private subnets"
+}
+
+variable "public_subnets_tags" {
+  type = map
+  default = {}
+  description = "Tags to apply to public subnets"
+}


### PR DESCRIPTION
## what
Add the ability to set tags on subnets, based on whether they are public or private.

## why
In eks, to allow a load balancer on a subnet, the tag "kubernetes.io/role/elb" or "kubernetes.io/role/internal-elb" must be set. This allows setting these values for public and private subnets, respectively.