### PR TITLE
Add `private_subnets_additional_tags` and `public_subnets_additional_tags` variables. Change AWS region for tests.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017-2019 Cloud Posse, LLC
+   Copyright 2017-2020 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -206,13 +206,15 @@ Available targets:
 | label_order | The naming order of the ID output and Name tag | list(string) | `<list>` | no |
 | map_public_ip_on_launch | Instances launched into a public subnet should be assigned a public IP address | bool | `true` | no |
 | max_subnet_count | Sets the maximum amount of subnets to deploy. 0 will deploy a subnet for every provided availablility zone (in `availability_zones` variable) within the region | string | `0` | no |
-| name | Solution name, e.g. 'app' or 'jenkins' | string | `` | no |
+| name | Solution name, e.g. 'app' or 'cluster' | string | `` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | string | `` | no |
 | nat_gateway_enabled | Flag to enable/disable NAT Gateways to allow servers in the private subnets to access the Internet | bool | `true` | no |
 | nat_instance_enabled | Flag to enable/disable NAT Instances to allow servers in the private subnets to access the Internet | bool | `false` | no |
 | nat_instance_type | NAT Instance type | string | `t3.micro` | no |
 | private_network_acl_id | Network ACL ID that will be added to private subnets. If empty, a new ACL will be created | string | `` | no |
+| private_subnets_additional_tags | Additional tags to be added to private subnets | map(string) | `<map>` | no |
 | public_network_acl_id | Network ACL ID that will be added to public subnets. If empty, a new ACL will be created | string | `` | no |
+| public_subnets_additional_tags | Additional tags to be added to public subnets | map(string) | `<map>` | no |
 | regex_replace_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only hyphens, letters and digits are allowed, all other chars are removed | string | `/[^a-zA-Z0-9-]/` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | `` | no |
 | subnet_type_tag_key | Key for subnet type tag to provide information about the type of subnets, e.g. `cpco.io/subnet/type=private` or `cpco.io/subnet/type=public` | string | `cpco.io/subnet/type` | no |
@@ -323,7 +325,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2019 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2020 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -13,13 +13,15 @@
 | label_order | The naming order of the ID output and Name tag | list(string) | `<list>` | no |
 | map_public_ip_on_launch | Instances launched into a public subnet should be assigned a public IP address | bool | `true` | no |
 | max_subnet_count | Sets the maximum amount of subnets to deploy. 0 will deploy a subnet for every provided availablility zone (in `availability_zones` variable) within the region | string | `0` | no |
-| name | Solution name, e.g. 'app' or 'jenkins' | string | `` | no |
+| name | Solution name, e.g. 'app' or 'cluster' | string | `` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | string | `` | no |
 | nat_gateway_enabled | Flag to enable/disable NAT Gateways to allow servers in the private subnets to access the Internet | bool | `true` | no |
 | nat_instance_enabled | Flag to enable/disable NAT Instances to allow servers in the private subnets to access the Internet | bool | `false` | no |
 | nat_instance_type | NAT Instance type | string | `t3.micro` | no |
 | private_network_acl_id | Network ACL ID that will be added to private subnets. If empty, a new ACL will be created | string | `` | no |
+| private_subnets_additional_tags | Additional tags to be added to private subnets | map(string) | `<map>` | no |
 | public_network_acl_id | Network ACL ID that will be added to public subnets. If empty, a new ACL will be created | string | `` | no |
+| public_subnets_additional_tags | Additional tags to be added to public subnets | map(string) | `<map>` | no |
 | regex_replace_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only hyphens, letters and digits are allowed, all other chars are removed | string | `/[^a-zA-Z0-9-]/` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | `` | no |
 | subnet_type_tag_key | Key for subnet type tag to provide information about the type of subnets, e.g. `cpco.io/subnet/type=private` or `cpco.io/subnet/type=public` | string | `cpco.io/subnet/type` | no |

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -1,0 +1,9 @@
+region = "us-east-2"
+
+availability_zones = ["us-east-2a", "us-east-2b"]
+
+namespace = "eg"
+
+stage = "test"
+
+name = "subnets-vpc-test"

--- a/examples/complete/fixtures.us-west-1.tfvars
+++ b/examples/complete/fixtures.us-west-1.tfvars
@@ -1,9 +1,0 @@
-region = "us-west-1"
-
-availability_zones = ["us-west-1b", "us-west-1c"]
-
-namespace = "eg"
-
-stage = "test"
-
-name = "subnets-vpc-test"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.7.0"
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.8.1"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -1,19 +1,24 @@
 variable "region" {
-  type = string
+  type        = string
+  description = "AWS region"
 }
 
 variable "availability_zones" {
-  type = list(string)
+  type        = list(string)
+  description = "List of Availability Zones where subnets will be created"
 }
 
 variable "namespace" {
-  type = string
-}
-
-variable "name" {
-  type = string
+  type        = string
+  description = "Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp'"
 }
 
 variable "stage" {
-  type = string
+  type        = string
+  description = "Stage, e.g. 'prod', 'staging', 'dev', or 'test'"
+}
+
+variable "name" {
+  type        = string
+  description = "Solution/application name, e.g. 'app' or 'cluster'"
 }

--- a/label.tf
+++ b/label.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source              = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.0"
+  source              = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
   attributes          = var.attributes
   namespace           = var.namespace
   environment         = var.environment
@@ -52,7 +52,7 @@ variable "stage" {
 variable "name" {
   type        = string
   default     = ""
-  description = "Solution name, e.g. 'app' or 'jenkins'"
+  description = "Solution name, e.g. 'app' or 'cluster'"
 }
 
 variable "environment" {

--- a/nat-gateway.tf
+++ b/nat-gateway.tf
@@ -1,5 +1,5 @@
 module "nat_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
   context    = module.label.context
   attributes = distinct(compact(concat(module.label.attributes, ["nat"])))
 }

--- a/nat-instance.tf
+++ b/nat-instance.tf
@@ -1,5 +1,5 @@
 module "nat_instance_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
   context    = module.label.context
   attributes = distinct(compact(concat(module.label.attributes, ["nat", "instance"])))
 }

--- a/private.tf
+++ b/private.tf
@@ -1,10 +1,11 @@
 module "private_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
   context    = module.label.context
   attributes = compact(concat(module.label.attributes, ["private"]))
 
   tags = merge(
     module.label.tags,
+    var.private_subnets_additional_tags,
     map(var.subnet_type_tag_key, format(var.subnet_type_tag_value_format, "private"))
   )
 }

--- a/public.tf
+++ b/public.tf
@@ -1,10 +1,11 @@
 module "public_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
   context    = module.label.context
   attributes = compact(concat(module.label.attributes, ["public"]))
 
   tags = merge(
     module.label.tags,
+    var.public_subnets_additional_tags,
     map(var.subnet_type_tag_key, format(var.subnet_type_tag_value_format, "public"))
   )
 }

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -28,14 +28,14 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	privateSubnetCidrs := terraform.OutputList(t, terraformOptions, "private_subnet_cidrs")
 
-	expectedPrivateSubnetCidrs := []string{"172.16.0.0/18", "172.16.64.0/18"}
+	expectedPrivateSubnetCidrs := []string{"172.16.0.0/19", "172.16.32.0/19"}
 	// Verify we're getting back the outputs we expect
 	assert.Equal(t, expectedPrivateSubnetCidrs, privateSubnetCidrs)
 
 	// Run `terraform output` to get the value of an output variable
 	publicSubnetCidrs := terraform.OutputList(t, terraformOptions, "public_subnet_cidrs")
 
-	expectedPublicSubnetCidrs := []string{"172.16.128.0/18", "172.16.192.0/18"}
+	expectedPublicSubnetCidrs := []string{"172.16.96.0/19", "172.16.128.0/19"}
 	// Verify we're getting back the outputs we expect
 	assert.Equal(t, expectedPublicSubnetCidrs, publicSubnetCidrs)
 }

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -16,7 +16,7 @@ func TestExamplesComplete(t *testing.T) {
 		TerraformDir: "../../examples/complete",
 		Upgrade:      true,
 		// Variables to pass to our Terraform code using -var-file options
-		VarFiles: []string{"fixtures.us-west-1.tfvars"},
+		VarFiles: []string{"fixtures.us-east-2.tfvars"},
 	}
 
 	// At the end of the test, run `terraform destroy` to clean up any resources that were created

--- a/variables.tf
+++ b/variables.tf
@@ -76,3 +76,15 @@ variable "map_public_ip_on_launch" {
   default     = true
   description = "Instances launched into a public subnet should be assigned a public IP address"
 }
+
+variable "private_subnets_additional_tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags to be added to private subnets"
+}
+
+variable "public_subnets_additional_tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags to be added to public subnets"
+}


### PR DESCRIPTION
## what
* Add `private_subnets_additional_tags` and `public_subnets_additional_tags` variables
* Change AWS region for tests to `us-east-2`

## why
* EKS requires tagging all subnets with `kubernetes.io/cluster/<cluster-name>=shared` tag, but at the same time it requires tagging subnets with additional tags that are different for public and private subnets:

  - Private Subnet Tagging Requirement for Internal Load Balancers:
    `kubernetes.io/role/internal-elb=1`

  - Public Subnet Tagging Option for External Load Balancers:
    `kubernetes.io/role/elb`

This is required because EKS can't detect the type of subnets automatically

* Change AWS region for tests to `us-east-2` since we use it in all our tests and the `us-west-1` region is very limited

## references
* https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html

## related
* Closes #83 
* Closes #69 