### PR TITLE
fix: force list to avoid empty tuple warning when using element function

### DIFF
--- a/nat-gateway.tf
+++ b/nat-gateway.tf
@@ -35,8 +35,8 @@ resource "aws_eip" "default" {
 
 resource "aws_nat_gateway" "default" {
   count         = local.nat_gateways_count
-  allocation_id = element(aws_eip.default.*.id, count.index)
-  subnet_id     = element(aws_subnet.public.*.id, count.index)
+  allocation_id = element(aws_eip.default[*].id, count.index)
+  subnet_id     = element(aws_subnet.public[*].id, count.index)
 
   tags = merge(
     module.nat_label.tags,

--- a/nat-gateway.tf
+++ b/nat-gateway.tf
@@ -61,8 +61,9 @@ resource "aws_nat_gateway" "default" {
 
 resource "aws_route" "default" {
   count                  = local.nat_gateways_count
-  route_table_id         = element(aws_route_table.private[count.index].id, count.index)
-  nat_gateway_id         = element(aws_nat_gateway.default[count.index].id, count.index)
+  route_table_id         = element(concat(aws_route_table.private[*].id,list("")), count.index)
+  nat_gateway_id         = element(concat(aws_nat_gateway.default[*].id,list("")), count.index)
   destination_cidr_block = "0.0.0.0/0"
   depends_on             = [aws_route_table.private]
 }
+

--- a/nat-gateway.tf
+++ b/nat-gateway.tf
@@ -61,8 +61,8 @@ resource "aws_nat_gateway" "default" {
 
 resource "aws_route" "default" {
   count                  = local.nat_gateways_count
-  route_table_id         = element(aws_route_table.private.*.id, count.index)
-  nat_gateway_id         = element(aws_nat_gateway.default.*.id, count.index)
+  route_table_id         = element(aws_route_table.private[count.index].id, count.index)
+  nat_gateway_id         = element(aws_nat_gateway.default[count.index].id, count.index)
   destination_cidr_block = "0.0.0.0/0"
   depends_on             = [aws_route_table.private]
 }


### PR DESCRIPTION
## what
- Currently fails with "empty tuple" error when running a terraform plan example from [ecr repo](https://github.com/cloudposse/terraform-aws-ecs-alb-service-task)

## why
- Currently fails with "empty tuple" error for me.
- The documented solution for this is hashicorp/terraform/issues/11210#issuecomment-314317671
- Resolves current error on: `Call to function "element" failed: cannot use element function with an empty tuple` by ensuring the list exists even if empty. 

This worked for me, but I look forward to more feedback as seems odd that it would require this work around
