### PR TITLE
Allow create/delete timeouts for `aws_route` resource to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ Available targets:
 | additional\_tag\_map | Additional tags for appending to each tag map | `map(string)` | `{}` | no |
 | attributes | Any extra attributes for naming these resources | `list(string)` | `[]` | no |
 | availability\_zones | List of Availability Zones where subnets will be created | `list(string)` | n/a | yes |
+| aws\_route\_create\_timeout | Time to wait for AWS route creation specifed as a Go Duration, e.g. `2m` | `string` | `"2m"` | no |
+| aws\_route\_delete\_timeout | Time to wait for AWS route deletion specifed as a Go Duration, e.g. `5m` | `string` | `"5m"` | no |
 | cidr\_block | Base CIDR block which will be divided into subnet CIDR blocks (e.g. `10.0.0.0/16`) | `string` | n/a | yes |
 | context | Default context to use for passing state between label invocations | <pre>object({<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    enabled             = bool<br>    delimiter           = string<br>    attributes          = list(string)<br>    label_order         = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": "",<br>  "enabled": true,<br>  "environment": "",<br>  "label_order": [],<br>  "name": "",<br>  "namespace": "",<br>  "regex_replace_chars": "",<br>  "stage": "",<br>  "tags": {}<br>}</pre> | no |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | `string` | `"-"` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -21,6 +21,8 @@
 | additional\_tag\_map | Additional tags for appending to each tag map | `map(string)` | `{}` | no |
 | attributes | Any extra attributes for naming these resources | `list(string)` | `[]` | no |
 | availability\_zones | List of Availability Zones where subnets will be created | `list(string)` | n/a | yes |
+| aws\_route\_create\_timeout | Time to wait for AWS route creation specifed as a Go Duration, e.g. `2m` | `string` | `"2m"` | no |
+| aws\_route\_delete\_timeout | Time to wait for AWS route deletion specifed as a Go Duration, e.g. `5m` | `string` | `"5m"` | no |
 | cidr\_block | Base CIDR block which will be divided into subnet CIDR blocks (e.g. `10.0.0.0/16`) | `string` | n/a | yes |
 | context | Default context to use for passing state between label invocations | <pre>object({<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    enabled             = bool<br>    delimiter           = string<br>    attributes          = list(string)<br>    label_order         = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": "",<br>  "enabled": true,<br>  "environment": "",<br>  "label_order": [],<br>  "name": "",<br>  "namespace": "",<br>  "regex_replace_chars": "",<br>  "stage": "",<br>  "tags": {}<br>}</pre> | no |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | `string` | `"-"` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -11,14 +11,16 @@ module "vpc" {
 }
 
 module "subnets" {
-  source               = "../../"
-  availability_zones   = var.availability_zones
-  namespace            = var.namespace
-  stage                = var.stage
-  name                 = var.name
-  vpc_id               = module.vpc.vpc_id
-  igw_id               = module.vpc.igw_id
-  cidr_block           = module.vpc.vpc_cidr_block
-  nat_gateway_enabled  = false
-  nat_instance_enabled = false
+  source                   = "../../"
+  availability_zones       = var.availability_zones
+  namespace                = var.namespace
+  stage                    = var.stage
+  name                     = var.name
+  vpc_id                   = module.vpc.vpc_id
+  igw_id                   = module.vpc.igw_id
+  cidr_block               = module.vpc.vpc_cidr_block
+  nat_gateway_enabled      = false
+  nat_instance_enabled     = false
+  aws_route_create_timeout = "5m"
+  aws_route_delete_timeout = "10m"
 }

--- a/nat-gateway.tf
+++ b/nat-gateway.tf
@@ -69,4 +69,9 @@ resource "aws_route" "default" {
   nat_gateway_id         = element(aws_nat_gateway.default.*.id, count.index)
   destination_cidr_block = "0.0.0.0/0"
   depends_on             = [aws_route_table.private]
+
+  timeouts {
+    create = var.aws_route_create_timeout
+    delete = var.aws_route_delete_timeout
+  }
 }

--- a/nat-instance.tf
+++ b/nat-instance.tf
@@ -134,4 +134,9 @@ resource "aws_route" "nat_instance" {
   instance_id            = element(aws_instance.nat_instance.*.id, count.index)
   destination_cidr_block = "0.0.0.0/0"
   depends_on             = [aws_route_table.private]
+
+  timeouts {
+    create = var.aws_route_create_timeout
+    delete = var.aws_route_delete_timeout
+  }
 }

--- a/public.tf
+++ b/public.tf
@@ -64,6 +64,11 @@ resource "aws_route" "public" {
   route_table_id         = join("", aws_route_table.public.*.id)
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = var.igw_id
+
+  timeouts {
+    create = var.aws_route_create_timeout
+    delete = var.aws_route_delete_timeout
+  }
 }
 
 resource "aws_route_table_association" "public" {

--- a/variables.tf
+++ b/variables.tf
@@ -89,6 +89,18 @@ variable "map_public_ip_on_launch" {
   description = "Instances launched into a public subnet should be assigned a public IP address"
 }
 
+variable "aws_route_create_timeout" {
+  type        = string
+  default     = "2m"
+  description = "Time to wait for AWS route creation specifed as a Go Duration, e.g. `2m`"
+}
+
+variable "aws_route_delete_timeout" {
+  type        = string
+  default     = "5m"
+  description = "Time to wait for AWS route deletion specifed as a Go Duration, e.g. `5m`"
+}
+
 variable "private_subnets_additional_tags" {
   type        = map(string)
   default     = {}


### PR DESCRIPTION
## what
* Added variables to allow specifying create/delete timeouts for all `aws_route` resources created by this module
* Included these in examples/complete

## why
* Some dependent modules have been experiencing errors related to aws_route not being ready - see terraform-providers/terraform-provider-aws#12073
* This will allow downstream module tests to increase the timeout (particularly create)

## references
* https://github.com/terraform-providers/terraform-provider-aws/issues/12073

