### PR TITLE
Bumping AWS provider version to ~> 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Available targets:
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 | local | ~> 1.2 |
 | null | ~> 2.0 |
 | template | ~> 2.0 |
@@ -187,7 +187,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 | local | ~> 1.2 |
 | null | ~> 2.0 |
 | template | ~> 2.0 |
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Inputs
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.8.1"
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.16.2"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name

--- a/examples/existing-ips/main.tf
+++ b/examples/existing-ips/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.8.1"
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.16.2"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws      = "~> 2.0"
+    aws      = "~> 3.0"
     template = "~> 2.0"
     local    = "~> 1.2"
     null     = "~> 2.0"


### PR DESCRIPTION
## what
* Bumping our AWS provider to version 3
* Bumping `terraform-aws-vpc` version to latest in examples

## why
* Allows us to take advantage of some newer Terraform features when deploying EKS
* We need this to be in line with `terraform-aws-eks-node-group`, which will provide us with the ability to specify custom launch templates via `aws_eks_node_group` (for custom EC2 tagging)

## references

#### https://github.com/aws/containers-roadmap/issues/585