### PR TITLE
fix: use the correct delimiter value with nat-instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -242,6 +243,7 @@ Available targets:
 | public\_subnet\_cidrs | CIDR blocks of the created public subnets |
 | public\_subnet\_ids | IDs of the created public subnets |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -67,3 +68,4 @@
 | public\_subnet\_cidrs | CIDR blocks of the created public subnets |
 | public\_subnet\_ids | IDs of the created public subnets |
 
+<!-- markdownlint-restore -->

--- a/nat-instance.tf
+++ b/nat-instance.tf
@@ -78,11 +78,11 @@ resource "aws_instance" "nat_instance" {
       "Name" = format(
         "%s%s%s",
         module.nat_label.id,
-        var.delimiter,
+        local.delimiter,
         replace(
           element(var.availability_zones, count.index),
           "-",
-          var.delimiter
+          local.delimiter
         )
       )
     }
@@ -108,11 +108,11 @@ resource "aws_eip" "nat_instance" {
       "Name" = format(
         "%s%s%s",
         module.nat_label.id,
-        var.delimiter,
+        local.delimiter,
         replace(
           element(var.availability_zones, count.index),
           "-",
-          var.delimiter
+          local.delimiter
         )
       )
     }


### PR DESCRIPTION
## what
* Replaces `var.delimiter` with `local.delimiter` in `nat-instance.tf`

## why
* After the changes done in #97 creating a NAT instance is failing because it tries to do a replace on a `null` value

## references
* Refs #97

