### PR TITLE
Use compact AZ codes in tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,13 +173,12 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
-<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0, < 0.14.0 |
-| aws | >= 2.0, < 4.0 |
+| terraform | >= 0.12.0 |
+| aws | >= 2.0 |
 | local | ~> 1.2 |
 | null | ~> 2.0 |
 | template | ~> 2.0 |
@@ -188,7 +187,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.0, < 4.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 
@@ -196,6 +195,7 @@ Available targets:
 |------|-------------|------|---------|:--------:|
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| availability\_zone\_attribute\_style | The style of Availability Zone code to use in tags and names. One of `full`, `short`, or `fixed`. | `string` | `"short"` | no |
 | availability\_zones | List of Availability Zones where subnets will be created | `list(string)` | n/a | yes |
 | aws\_route\_create\_timeout | Time to wait for AWS route creation specifed as a Go Duration, e.g. `2m` | `string` | `"2m"` | no |
 | aws\_route\_delete\_timeout | Time to wait for AWS route deletion specifed as a Go Duration, e.g. `5m` | `string` | `"5m"` | no |
@@ -243,7 +243,6 @@ Available targets:
 | public\_subnet\_cidrs | CIDR blocks of the created public subnets |
 | public\_subnet\_ids | IDs of the created public subnets |
 
-<!-- markdownlint-restore -->
 
 
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -243,6 +244,7 @@ Available targets:
 | public\_subnet\_cidrs | CIDR blocks of the created public subnets |
 | public\_subnet\_ids | IDs of the created public subnets |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/context.tf
+++ b/context.tf
@@ -1,4 +1,8 @@
 #
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
 # Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
 # and then place it in your Terraform module to automatically get
 # Cloud Posse's standard configuration inputs suitable for passing
@@ -13,11 +17,28 @@
 # For example, when using defaults, `module.this.context.delimiter`
 # will be null, and `module.this.delimiter` will be `-` (hyphen).
 #
-# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
-# All other instances of this file should be a copy of that one
-#
+
+module "this" {
+  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+
+  context = var.context
+}
 
 # Copy contents of cloudposse/terraform-null-label/variables.tf here
+
 variable "context" {
   type = object({
     enabled             = bool
@@ -53,7 +74,7 @@ variable "context" {
     Leave string and numeric variables as `null` to use default value.
     Individual variable settings (non-null) override settings in context object,
     except for attributes, tags, and additional_tag_map, which are merged.
-EOT
+  EOT
 }
 
 variable "enabled" {
@@ -92,7 +113,7 @@ variable "delimiter" {
   description = <<-EOT
     Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.
     Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
-EOT
+  EOT
 }
 
 variable "attributes" {
@@ -120,7 +141,7 @@ variable "label_order" {
     The naming order of the id output and Name tag.
     Defaults to ["namespace", "environment", "stage", "name", "attributes"].
     You can omit any of the 5 elements, but at least one must be present.
-EOT
+  EOT
 }
 
 variable "regex_replace_chars" {
@@ -129,7 +150,7 @@ variable "regex_replace_chars" {
   description = <<-EOT
     Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.
     If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
-EOT
+  EOT
 }
 
 variable "id_length_limit" {
@@ -140,33 +161,7 @@ variable "id_length_limit" {
     Set to `0` for unlimited length.
     Set to `null` for default, which is `0`.
     Does not affect `id_full`.
-EOT
+  EOT
 }
 
 #### End of copy of cloudposse/terraform-null-label/variables.tf
-
-#
-# Ensure all variables above are includes in input to module "this" below
-#
-# Modules should access the whole context as `module.this.context`
-# and access individual variables as `module.this.context.<var>`,
-# for example, `module.this.context.enabled`
-#
-module "this" {
-  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.1"
-
-  enabled             = var.enabled
-  namespace           = var.namespace
-  environment         = var.environment
-  stage               = var.stage
-  name                = var.name
-  delimiter           = var.delimiter
-  attributes          = var.attributes
-  tags                = var.tags
-  additional_tag_map  = var.additional_tag_map
-  label_order         = var.label_order
-  regex_replace_chars = var.regex_replace_chars
-  id_length_limit     = var.id_length_limit
-
-  context = var.context
-}

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -68,3 +69,4 @@
 | public\_subnet\_cidrs | CIDR blocks of the created public subnets |
 | public\_subnet\_ids | IDs of the created public subnets |
 
+<!-- markdownlint-restore -->

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,10 +1,9 @@
-<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0, < 0.14.0 |
-| aws | >= 2.0, < 4.0 |
+| terraform | >= 0.12.0 |
+| aws | >= 2.0 |
 | local | ~> 1.2 |
 | null | ~> 2.0 |
 | template | ~> 2.0 |
@@ -13,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.0, < 4.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 
@@ -21,6 +20,7 @@
 |------|-------------|------|---------|:--------:|
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| availability\_zone\_attribute\_style | The style of Availability Zone code to use in tags and names. One of `full`, `short`, or `fixed`. | `string` | `"short"` | no |
 | availability\_zones | List of Availability Zones where subnets will be created | `list(string)` | n/a | yes |
 | aws\_route\_create\_timeout | Time to wait for AWS route creation specifed as a Go Duration, e.g. `2m` | `string` | `"2m"` | no |
 | aws\_route\_delete\_timeout | Time to wait for AWS route deletion specifed as a Go Duration, e.g. `5m` | `string` | `"5m"` | no |
@@ -68,4 +68,3 @@
 | public\_subnet\_cidrs | CIDR blocks of the created public subnets |
 | public\_subnet\_ids | IDs of the created public subnets |
 
-<!-- markdownlint-restore -->

--- a/examples/complete/context.tf
+++ b/examples/complete/context.tf
@@ -1,4 +1,8 @@
 #
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
 # Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
 # and then place it in your Terraform module to automatically get
 # Cloud Posse's standard configuration inputs suitable for passing
@@ -13,11 +17,28 @@
 # For example, when using defaults, `module.this.context.delimiter`
 # will be null, and `module.this.delimiter` will be `-` (hyphen).
 #
-# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
-# All other instances of this file should be a copy of that one
-#
+
+module "this" {
+  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+
+  context = var.context
+}
 
 # Copy contents of cloudposse/terraform-null-label/variables.tf here
+
 variable "context" {
   type = object({
     enabled             = bool
@@ -53,7 +74,7 @@ variable "context" {
     Leave string and numeric variables as `null` to use default value.
     Individual variable settings (non-null) override settings in context object,
     except for attributes, tags, and additional_tag_map, which are merged.
-EOT
+  EOT
 }
 
 variable "enabled" {
@@ -92,7 +113,7 @@ variable "delimiter" {
   description = <<-EOT
     Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.
     Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
-EOT
+  EOT
 }
 
 variable "attributes" {
@@ -120,7 +141,7 @@ variable "label_order" {
     The naming order of the id output and Name tag.
     Defaults to ["namespace", "environment", "stage", "name", "attributes"].
     You can omit any of the 5 elements, but at least one must be present.
-EOT
+  EOT
 }
 
 variable "regex_replace_chars" {
@@ -129,7 +150,7 @@ variable "regex_replace_chars" {
   description = <<-EOT
     Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.
     If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
-EOT
+  EOT
 }
 
 variable "id_length_limit" {
@@ -140,33 +161,7 @@ variable "id_length_limit" {
     Set to `0` for unlimited length.
     Set to `null` for default, which is `0`.
     Does not affect `id_full`.
-EOT
+  EOT
 }
 
 #### End of copy of cloudposse/terraform-null-label/variables.tf
-
-#
-# Ensure all variables above are includes in input to module "this" below
-#
-# Modules should access the whole context as `module.this.context`
-# and access individual variables as `module.this.context.<var>`,
-# for example, `module.this.context.enabled`
-#
-module "this" {
-  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.1"
-
-  enabled             = var.enabled
-  namespace           = var.namespace
-  environment         = var.environment
-  stage               = var.stage
-  name                = var.name
-  delimiter           = var.delimiter
-  attributes          = var.attributes
-  tags                = var.tags
-  additional_tag_map  = var.additional_tag_map
-  label_order         = var.label_order
-  regex_replace_chars = var.regex_replace_chars
-  id_length_limit     = var.id_length_limit
-
-  context = var.context
-}

--- a/main.tf
+++ b/main.tf
@@ -22,4 +22,14 @@ data "aws_eip" "nat_ips" {
 
 locals {
   use_existing_eips = length(var.existing_nat_ips) > 0
+  map_map = {
+    short = "to_short"
+    fixed = "to_fixed"
+    full  = "identity"
+  }
+  az_map = module.utils.region_az_alt_code_maps[local.map_map[var.availability_zone_attribute_style]]
+}
+
+module "utils" {
+  source = "git::https://github.com/cloudposse/terraform-aws-utils.git?ref=tags/0.1.0"
 }

--- a/nat-gateway.tf
+++ b/nat-gateway.tf
@@ -1,5 +1,5 @@
 module "nat_label" {
-  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.1"
+  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
 
   attributes = ["nat"]
 

--- a/nat-gateway.tf
+++ b/nat-gateway.tf
@@ -20,16 +20,7 @@ resource "aws_eip" "default" {
   tags = merge(
     module.private_label.tags,
     {
-      "Name" = format(
-        "%s%s%s",
-        module.private_label.id,
-        local.delimiter,
-        replace(
-          element(var.availability_zones, count.index),
-          "-",
-          local.delimiter
-        )
-      )
+      "Name" = format("%s%s%s", module.private_label.id, local.delimiter, local.az_map[element(var.availability_zones, count.index)])
     }
   )
 
@@ -46,16 +37,7 @@ resource "aws_nat_gateway" "default" {
   tags = merge(
     module.nat_label.tags,
     {
-      "Name" = format(
-        "%s%s%s",
-        module.nat_label.id,
-        local.delimiter,
-        replace(
-          element(var.availability_zones, count.index),
-          "-",
-          local.delimiter
-        )
-      )
+      "Name" = format("%s%s%s", module.nat_label.id, local.delimiter, local.az_map[element(var.availability_zones, count.index)])
     }
   )
 

--- a/nat-instance.tf
+++ b/nat-instance.tf
@@ -1,5 +1,5 @@
 module "nat_instance_label" {
-  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.1"
+  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
 
   attributes = ["nat", "instance"]
 

--- a/nat-instance.tf
+++ b/nat-instance.tf
@@ -75,16 +75,7 @@ resource "aws_instance" "nat_instance" {
   tags = merge(
     module.nat_instance_label.tags,
     {
-      "Name" = format(
-        "%s%s%s",
-        module.nat_label.id,
-        local.delimiter,
-        replace(
-          element(var.availability_zones, count.index),
-          "-",
-          local.delimiter
-        )
-      )
+      "Name" = format("%s%s%s", module.nat_instance_label.id, local.delimiter, local.az_map[element(var.availability_zones, count.index)])
     }
   )
 
@@ -105,16 +96,7 @@ resource "aws_eip" "nat_instance" {
   tags = merge(
     module.nat_instance_label.tags,
     {
-      "Name" = format(
-        "%s%s%s",
-        module.nat_label.id,
-        local.delimiter,
-        replace(
-          element(var.availability_zones, count.index),
-          "-",
-          local.delimiter
-        )
-      )
+      "Name" = format("%s%s%s", module.nat_instance_label.id, local.delimiter, local.az_map[element(var.availability_zones, count.index)])
     }
   )
 

--- a/private.tf
+++ b/private.tf
@@ -1,5 +1,5 @@
 module "private_label" {
-  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.1"
+  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
 
   attributes = ["private"]
   tags = merge(

--- a/private.tf
+++ b/private.tf
@@ -29,7 +29,7 @@ resource "aws_subnet" "private" {
   tags = merge(
     module.private_label.tags,
     {
-      "Name" = format("%s%s%s", module.private_label.id, local.delimiter, module.az_map.to_short[element(var.availability_zones, count.index)])
+      "Name" = format("%s%s%s", module.private_label.id, local.delimiter, local.az_map[element(var.availability_zones, count.index)])
     }
   )
 
@@ -46,16 +46,7 @@ resource "aws_route_table" "private" {
   tags = merge(
     module.private_label.tags,
     {
-      "Name" = format(
-        "%s%s%s",
-        module.private_label.id,
-        local.delimiter,
-        replace(
-          element(var.availability_zones, count.index),
-          "-",
-          local.delimiter
-        )
-      )
+      "Name" = format("%s%s%s", module.private_label.id, local.delimiter, local.az_map[element(var.availability_zones, count.index)])
     }
   )
 }

--- a/private.tf
+++ b/private.tf
@@ -29,16 +29,7 @@ resource "aws_subnet" "private" {
   tags = merge(
     module.private_label.tags,
     {
-      "Name" = format(
-        "%s%s%s",
-        module.private_label.id,
-        local.delimiter,
-        replace(
-          element(var.availability_zones, count.index),
-          "-",
-          local.delimiter
-        )
-      )
+      "Name" = format("%s%s%s", module.private_label.id, local.delimiter, module.az_map.to_short[element(var.availability_zones, count.index)])
     }
   )
 

--- a/public.tf
+++ b/public.tf
@@ -33,7 +33,7 @@ resource "aws_subnet" "public" {
   tags = merge(
     module.public_label.tags,
     {
-      "Name" = format("%s%s%s", module.public_label.id, local.delimiter, module.az_map.to_short[element(var.availability_zones, count.index)])
+      "Name" = format("%s%s%s", module.public_label.id, local.delimiter, local.az_map[element(var.availability_zones, count.index)])
     }
   )
 

--- a/public.tf
+++ b/public.tf
@@ -1,5 +1,5 @@
 module "public_label" {
-  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.1"
+  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
 
   attributes = ["public"]
   tags = merge(
@@ -33,16 +33,7 @@ resource "aws_subnet" "public" {
   tags = merge(
     module.public_label.tags,
     {
-      "Name" = format(
-        "%s%s%s",
-        module.public_label.id,
-        local.delimiter,
-        replace(
-          element(var.availability_zones, count.index),
-          "-",
-          local.delimiter
-        )
-      )
+      "Name" = format("%s%s%s", module.public_label.id, local.delimiter, module.az_map.to_short[element(var.availability_zones, count.index)])
     }
   )
 

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,12 @@ variable "availability_zones" {
   description = "List of Availability Zones where subnets will be created"
 }
 
+variable "availability_zone_attribute_style" {
+  type        = string
+  default     = "short"
+  description = "The style of Availability Zone code to use in tags and names. One of `full`, `short`, or `fixed`."
+}
+
 variable "vpc_default_route_table_id" {
   type        = string
   default     = ""

--- a/versions.tf
+++ b/versions.tf
@@ -1,8 +1,8 @@
 terraform {
-  required_version = ">= 0.12.0, < 0.14.0"
+  required_version = ">= 0.12.0"
 
   required_providers {
-    aws      = ">= 2.0, < 4.0"
+    aws      = ">= 2.0"
     template = "~> 2.0"
     local    = "~> 1.2"
     null     = "~> 2.0"


### PR DESCRIPTION
## what

- When resources are tagged with names that have the Availability Zone appended, use Cloud Posse's new "short" AZ codes
- Update `context.tf` and `null-label` to v0.19.2

## why

- Full Availability Zone (AZ) codes have 2 dashes in them (e.g. "us-east-2") and Cloud Posse's naming convention defaults to using dashes as token separators. Additionally, previous code replaced the dashes in the AZ codes with whatever delimiter was in use for labels. This means that the previous availability zone was treated as 3 tokens when it is more appropriately treated as 1 token. Cloud Posse's new short codes use only digits and lower case letters, ensuring they are always treated as a single token.
- Stay in sync with other modules

## references

Cloud Posse's AWS AZ [short codes](https://github.com/cloudposse/terraform-aws-utils#outputs)