### PR TITLE
Ignore 2 tfsec warnings

### DIFF
--- a/nat-instance.tf
+++ b/nat-instance.tf
@@ -28,7 +28,7 @@ resource "aws_security_group_rule" "nat_instance_egress" {
   from_port         = 0
   to_port           = 0
   protocol          = "-1"
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:AWS007
   security_group_id = join("", aws_security_group.nat_instance.*.id)
   type              = "egress"
 }
@@ -83,7 +83,7 @@ resource "aws_instance" "nat_instance" {
   # https://docs.aws.amazon.com/vpc/latest/userguide/VPC_NAT_Instance.html#EIP_Disable_SrcDestCheck
   source_dest_check = false
 
-  associate_public_ip_address = true
+  associate_public_ip_address = true #tfsec:ignore:AWS012
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
## what
* Ignore 2 [tfsec](https://github.com/tfsec/tfsec) warnings

## why
* We are okay with the CIDR block on the NAT instance's egress being 0.0.0.0/0
* We are okay with the the NAT instance having a public IP address (?)

## references
![image](https://user-images.githubusercontent.com/16000938/97912093-5194e600-1d1a-11eb-8fae-e77b8b48c287.png)


