### PR TITLE
remove check for existing ips on local.nat_gateways_count

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,23 @@ module "subnets" {
 }
 ```
 
+```hcl
+module "subnets_with_existing_ips" {
+  source = "cloudposse/dynamic-subnets/aws"
+  # Cloud Posse recommends pinning every module to a specific version
+  # version = "x.x.x"
+  namespace           = "eg"
+  stage               = "prod"
+  name                = "app"
+  vpc_id              = "vpc-XXXXXXXX"
+  igw_id              = "igw-XXXXXXXX"
+  cidr_block          = "10.0.0.0/16"
+  availability_zones  = ["us-east-1a", "us-east-1b"]
+  nat_gateway_enabled = true
+  nat_elastic_ips     = ["1.2.3.4", "1.2.3.5"]
+}
+```
+
 Learn about [using providers](https://www.terraform.io/docs/configuration-0-11/modules.html#providers-within-modules) with terraform modules.
 
 
@@ -406,8 +423,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 ### Contributors
 
 <!-- markdownlint-disable -->
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Sergey Vasilyev][s2504s_avatar]][s2504s_homepage]<br/>[Sergey Vasilyev][s2504s_homepage] | [![Vladimir][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir][SweetOps_homepage] | [![Konstantin B][comeanother_avatar]][comeanother_homepage]<br/>[Konstantin B][comeanother_homepage] | [![dcowan-vestmark][dcowan-vestmark_avatar]][dcowan-vestmark_homepage]<br/>[dcowan-vestmark][dcowan-vestmark_homepage] | [![Ivan Pinatti][ivan-pinatti_avatar]][ivan-pinatti_homepage]<br/>[Ivan Pinatti][ivan-pinatti_homepage] | [![Oscar Sullivan][osulli_avatar]][osulli_homepage]<br/>[Oscar Sullivan][osulli_homepage] |
-|---|---|---|---|---|---|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Sergey Vasilyev][s2504s_avatar]][s2504s_homepage]<br/>[Sergey Vasilyev][s2504s_homepage] | [![Vladimir][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir][SweetOps_homepage] | [![Konstantin B][comeanother_avatar]][comeanother_homepage]<br/>[Konstantin B][comeanother_homepage] | [![dcowan-vestmark][dcowan-vestmark_avatar]][dcowan-vestmark_homepage]<br/>[dcowan-vestmark][dcowan-vestmark_homepage] | [![Ivan Pinatti][ivan-pinatti_avatar]][ivan-pinatti_homepage]<br/>[Ivan Pinatti][ivan-pinatti_homepage] | [![Oscar Sullivan][osulli_avatar]][osulli_homepage]<br/>[Oscar Sullivan][osulli_homepage] | [![Joe Niland][joe-niland_avatar]][joe-niland_homepage]<br/>[Joe Niland][joe-niland_homepage] |
+|---|---|---|---|---|---|---|---|---|
 <!-- markdownlint-restore -->
 
   [osterman_homepage]: https://github.com/osterman
@@ -426,6 +443,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [ivan-pinatti_avatar]: https://img.cloudposse.com/150x150/https://github.com/ivan-pinatti.png
   [osulli_homepage]: https://github.com/osulli
   [osulli_avatar]: https://img.cloudposse.com/150x150/https://github.com/osulli.png
+  [joe-niland_homepage]: https://github.com/joe-niland
+  [joe-niland_avatar]: https://img.cloudposse.com/150x150/https://github.com/joe-niland.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.md
+++ b/README.md
@@ -216,7 +216,6 @@ Available targets:
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
-| existing\_nat\_ips | Existing Elastic IPs to attach to the NAT Gateway or Instance instead of creating a new one. | `list(string)` | `[]` | no |
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | igw\_id | Internet Gateway ID the public route table will point to (e.g. `igw-9c26a123`) | `string` | n/a | yes |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
@@ -224,6 +223,7 @@ Available targets:
 | max\_subnet\_count | Sets the maximum amount of subnets to deploy. 0 will deploy a subnet for every provided availablility zone (in `availability_zones` variable) within the region | `number` | `0` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
+| nat\_elastic\_ips | Existing Elastic IPs to attach to the NAT Gateway(s) or Instance(s) instead of creating new ones. | `list(string)` | `[]` | no |
 | nat\_gateway\_enabled | Flag to enable/disable NAT Gateways to allow servers in the private subnets to access the Internet | `bool` | `true` | no |
 | nat\_instance\_enabled | Flag to enable/disable NAT Instances to allow servers in the private subnets to access the Internet | `bool` | `false` | no |
 | nat\_instance\_type | NAT Instance type | `string` | `"t3.micro"` | no |

--- a/README.yaml
+++ b/README.yaml
@@ -68,6 +68,23 @@ usage: |-
   }
   ```
 
+  ```hcl
+  module "subnets_with_existing_ips" {
+    source = "cloudposse/dynamic-subnets/aws"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version = "x.x.x"
+    namespace           = "eg"
+    stage               = "prod"
+    name                = "app"
+    vpc_id              = "vpc-XXXXXXXX"
+    igw_id              = "igw-XXXXXXXX"
+    cidr_block          = "10.0.0.0/16"
+    availability_zones  = ["us-east-1a", "us-east-1b"]
+    nat_gateway_enabled = true
+    nat_elastic_ips     = ["1.2.3.4", "1.2.3.5"]
+  }
+  ```
+
   Learn about [using providers](https://www.terraform.io/docs/configuration-0-11/modules.html#providers-within-modules) with terraform modules.
 include:
   - "docs/design.md"
@@ -91,3 +108,5 @@ contributors:
     github: "ivan-pinatti"
   - name: "Oscar Sullivan"
     github: "osulli"
+  - name: "Joe Niland"
+    github: "joe-niland"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -30,7 +30,6 @@
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
-| existing\_nat\_ips | Existing Elastic IPs to attach to the NAT Gateway or Instance instead of creating a new one. | `list(string)` | `[]` | no |
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | igw\_id | Internet Gateway ID the public route table will point to (e.g. `igw-9c26a123`) | `string` | n/a | yes |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
@@ -38,6 +37,7 @@
 | max\_subnet\_count | Sets the maximum amount of subnets to deploy. 0 will deploy a subnet for every provided availablility zone (in `availability_zones` variable) within the region | `number` | `0` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
+| nat\_elastic\_ips | Existing Elastic IPs to attach to the NAT Gateway(s) or Instance(s) instead of creating new ones. | `list(string)` | `[]` | no |
 | nat\_gateway\_enabled | Flag to enable/disable NAT Gateways to allow servers in the private subnets to access the Internet | `bool` | `true` | no |
 | nat\_instance\_enabled | Flag to enable/disable NAT Instances to allow servers in the private subnets to access the Internet | `bool` | `false` | no |
 | nat\_instance\_type | NAT Instance type | `string` | `"t3.micro"` | no |

--- a/examples/existing-ips/fixtures.us-east-2.tfvars
+++ b/examples/existing-ips/fixtures.us-east-2.tfvars
@@ -7,5 +7,3 @@ namespace = "eg"
 stage = "test"
 
 name = "subnets-vpc-test"
-
-existing_nat_ips = ["3.52.100.1", "3.52.100.2", "3.52.100.3"]

--- a/examples/existing-ips/main.tf
+++ b/examples/existing-ips/main.tf
@@ -12,7 +12,7 @@ module "vpc" {
 }
 
 resource "aws_eip" "nat_ips" {
-  for_each = var.assign_elastic_ips ? toset(var.availability_zones) : []
+  for_each = toset(var.availability_zones)
   vpc      = true
 
   depends_on = [

--- a/examples/existing-ips/main.tf
+++ b/examples/existing-ips/main.tf
@@ -11,6 +11,15 @@ module "vpc" {
   context = module.this.context
 }
 
+resource "aws_eip" "nat_ips" {
+  for_each = var.assign_elastic_ips ? toset(var.availability_zones) : []
+  vpc      = true
+
+  depends_on = [
+    module.vpc
+  ]
+}
+
 module "subnets" {
   source = "../../"
 
@@ -18,7 +27,7 @@ module "subnets" {
   vpc_id               = module.vpc.vpc_id
   igw_id               = module.vpc.igw_id
   cidr_block           = module.vpc.vpc_cidr_block
-  existing_nat_ips     = var.existing_nat_ips
+  nat_elastic_ips      = [for az, eip in aws_eip.nat_ips : eip.public_ip]
   nat_gateway_enabled  = true
   nat_instance_enabled = false
 

--- a/examples/existing-ips/variables.tf
+++ b/examples/existing-ips/variables.tf
@@ -7,9 +7,3 @@ variable "availability_zones" {
   type        = list(string)
   description = "List of Availability Zones where subnets will be created"
 }
-
-variable "existing_nat_ips" {
-  type        = list(string)
-  default     = []
-  description = "Existing Elastic IPs to attach to the NAT Gateway or Instance instead of creating a new one."
-}

--- a/main.tf
+++ b/main.tf
@@ -16,12 +16,12 @@ locals {
 }
 
 data "aws_eip" "nat_ips" {
-  count     = local.enabled ? length(var.existing_nat_ips) : 0
-  public_ip = element(var.existing_nat_ips, count.index)
+  count     = local.enabled ? length(var.nat_elastic_ips) : 0
+  public_ip = element(var.nat_elastic_ips, count.index)
 }
 
 locals {
-  use_existing_eips = length(var.existing_nat_ips) > 0
+  use_existing_eips = length(var.nat_elastic_ips) > 0
   map_map = {
     short = "to_short"
     fixed = "to_fixed"

--- a/nat-gateway.tf
+++ b/nat-gateway.tf
@@ -11,7 +11,7 @@ locals {
   nat_gateway_eip_count   = local.use_existing_eips ? 0 : local.nat_gateways_count
   gateway_eip_allocations = local.use_existing_eips ? data.aws_eip.nat_ips.*.id : aws_eip.default.*.id
   eips_allocations        = local.use_existing_eips ? data.aws_eip.nat_ips.*.id : aws_eip.default.*.id
-  nat_gateways_count      = var.nat_gateway_enabled && ! local.use_existing_eips ? length(var.availability_zones) : 0
+  nat_gateways_count      = var.nat_gateway_enabled ? length(var.availability_zones) : 0
 }
 
 resource "aws_eip" "default" {

--- a/nat-instance.tf
+++ b/nat-instance.tf
@@ -10,7 +10,7 @@ module "nat_instance_label" {
 locals {
   cidr_block               = var.cidr_block != "" ? var.cidr_block : join("", data.aws_vpc.default.*.cidr_block)
   nat_instance_enabled     = var.nat_instance_enabled ? 1 : 0
-  nat_instance_count       = var.nat_instance_enabled && ! local.use_existing_eips ? length(var.availability_zones) : 0
+  nat_instance_count       = var.nat_instance_enabled ? length(var.availability_zones) : 0
   nat_instance_eip_count   = local.use_existing_eips ? 0 : local.nat_instance_count
   instance_eip_allocations = local.use_existing_eips ? data.aws_eip.nat_ips.*.id : aws_eip.nat_instance.*.id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -77,10 +77,10 @@ variable "nat_instance_type" {
   default     = "t3.micro"
 }
 
-variable "existing_nat_ips" {
+variable "nat_elastic_ips" {
   type        = list(string)
   default     = []
-  description = "Existing Elastic IPs to attach to the NAT Gateway or Instance instead of creating a new one."
+  description = "Existing Elastic IPs to attach to the NAT Gateway(s) or Instance(s) instead of creating new ones."
 }
 
 variable "map_public_ip_on_launch" {


### PR DESCRIPTION
## what
* Removed check which caused NAT instances/gateways not to be created if existing Elastic IPs provided
* It's not clear why this check was added

## why
* We need the ability to assign existing elastic IPs to NAT instances/gateways

## references
* closes #101

