### PR TITLE
Remove use of deprecated map()

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,37 @@ Available targets:
 |------|---------|
 | aws | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| nat_instance_label | cloudposse/label/null | 0.24.1 |
+| nat_label | cloudposse/label/null | 0.24.1 |
+| private_label | cloudposse/label/null | 0.24.1 |
+| public_label | cloudposse/label/null | 0.24.1 |
+| this | cloudposse/label/null | 0.24.1 |
+| utils | cloudposse/utils/aws | 0.4.0 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/ami) |
+| [aws_availability_zones](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/availability_zones) |
+| [aws_eip](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/eip) |
+| [aws_eip](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/eip) |
+| [aws_eip_association](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/eip_association) |
+| [aws_instance](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/instance) |
+| [aws_nat_gateway](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/nat_gateway) |
+| [aws_network_acl](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/network_acl) |
+| [aws_route](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/route) |
+| [aws_route_table](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/route_table) |
+| [aws_route_table_association](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/route_table_association) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/security_group) |
+| [aws_security_group_rule](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/security_group_rule) |
+| [aws_subnet](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/subnet) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/vpc) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -297,7 +328,6 @@ Available targets:
 | public\_route\_table\_ids | IDs of the created public route tables |
 | public\_subnet\_cidrs | CIDR blocks of the created public subnets |
 | public\_subnet\_ids | IDs of the created public subnets |
-
 <!-- markdownlint-restore -->
 
 

--- a/README.md
+++ b/README.md
@@ -255,8 +255,8 @@ Available targets:
 |------|
 | [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/ami) |
 | [aws_availability_zones](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/availability_zones) |
-| [aws_eip](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/eip) |
 | [aws_eip](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/eip) |
+| [aws_eip](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/eip) |
 | [aws_eip_association](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/eip_association) |
 | [aws_instance](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/instance) |
 | [aws_nat_gateway](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/nat_gateway) |

--- a/README.md
+++ b/README.md
@@ -255,8 +255,8 @@ Available targets:
 |------|
 | [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/ami) |
 | [aws_availability_zones](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/availability_zones) |
-| [aws_eip](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/eip) |
 | [aws_eip](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/eip) |
+| [aws_eip](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/eip) |
 | [aws_eip_association](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/eip_association) |
 | [aws_instance](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/instance) |
 | [aws_nat_gateway](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/nat_gateway) |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -32,8 +32,8 @@
 |------|
 | [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/ami) |
 | [aws_availability_zones](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/availability_zones) |
-| [aws_eip](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/eip) |
 | [aws_eip](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/eip) |
+| [aws_eip](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/eip) |
 | [aws_eip_association](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/eip_association) |
 | [aws_instance](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/instance) |
 | [aws_nat_gateway](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/nat_gateway) |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -32,8 +32,8 @@
 |------|
 | [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/ami) |
 | [aws_availability_zones](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/availability_zones) |
-| [aws_eip](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/eip) |
 | [aws_eip](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/eip) |
+| [aws_eip](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/eip) |
 | [aws_eip_association](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/eip_association) |
 | [aws_instance](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/instance) |
 | [aws_nat_gateway](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/nat_gateway) |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -15,6 +15,37 @@
 |------|---------|
 | aws | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| nat_instance_label | cloudposse/label/null | 0.24.1 |
+| nat_label | cloudposse/label/null | 0.24.1 |
+| private_label | cloudposse/label/null | 0.24.1 |
+| public_label | cloudposse/label/null | 0.24.1 |
+| this | cloudposse/label/null | 0.24.1 |
+| utils | cloudposse/utils/aws | 0.4.0 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/ami) |
+| [aws_availability_zones](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/availability_zones) |
+| [aws_eip](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/eip) |
+| [aws_eip](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/eip) |
+| [aws_eip_association](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/eip_association) |
+| [aws_instance](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/instance) |
+| [aws_nat_gateway](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/nat_gateway) |
+| [aws_network_acl](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/network_acl) |
+| [aws_route](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/route) |
+| [aws_route_table](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/route_table) |
+| [aws_route_table_association](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/route_table_association) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/security_group) |
+| [aws_security_group_rule](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/security_group_rule) |
+| [aws_subnet](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/subnet) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/vpc) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -74,5 +105,4 @@
 | public\_route\_table\_ids | IDs of the created public route tables |
 | public\_subnet\_cidrs | CIDR blocks of the created public subnets |
 | public\_subnet\_ids | IDs of the created public subnets |
-
 <!-- markdownlint-restore -->

--- a/private.tf
+++ b/private.tf
@@ -5,7 +5,7 @@ module "private_label" {
   attributes = ["private"]
   tags = merge(
     var.private_subnets_additional_tags,
-    map(var.subnet_type_tag_key, format(var.subnet_type_tag_value_format, "private"))
+    { (var.subnet_type_tag_key) = format(var.subnet_type_tag_value_format, "private") }
   )
 
   context = module.this.context

--- a/public.tf
+++ b/public.tf
@@ -5,7 +5,7 @@ module "public_label" {
   attributes = ["public"]
   tags = merge(
     var.public_subnets_additional_tags,
-    map(var.subnet_type_tag_key, format(var.subnet_type_tag_value_format, "public"))
+    { (var.subnet_type_tag_key) = format(var.subnet_type_tag_value_format, "public") }
   )
 
   context = module.this.context


### PR DESCRIPTION
Remove use of deprecated map()

This function is removed in the upcoming Terraform 0.15. Since Terraform
0.12, you can create maps with a literal syntax instead.


## what
* No change to module behaviour

## why
Adds compatibility with Terraform 0.15. Without this, you'll see errors like:

```
│ Error: Error in function call
│
│   on .terraform/modules/dynamic_subnets/private.tf line 8, in module "private_label":
│    8:     map(var.subnet_type_tag_key, format(var.subnet_type_tag_value_format, "private"))
│     ├────────────────
│     │ var.subnet_type_tag_key is a string, known only after apply
│     │ var.subnet_type_tag_value_format is a string, known only after apply
│
│ Call to function "map" failed: the "map" function was deprecated in Terraform v0.12 and is no longer available; use tomap({ ... })
│ syntax to write a literal map.
```