### PR TITLE
Chore: bump null-label module versions to 0.25.0, update GitHub Actions Workflows

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,6 +17,7 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
+    - 'no-release'
   default: 'minor'
 
 categories:
@@ -46,7 +47,7 @@ template: |
 
 replacers:
 # Remove irrelevant information from Renovate bot
-- search: '/---\s+^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'
+- search: '/(?<=---\s+)+^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'
   replace: ''
 # Remove Renovate bot banner image
 - search: '/\[!\[[^\]]*Renovate\][^\]]*\](\([^)]*\))?\s*\n+/gm'

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,7 +3,9 @@ name: auto-release
 on:
   push:
     branches:
+      - main
       - master
+      - production
 
 jobs:
   publish:
@@ -14,11 +16,10 @@ jobs:
         id: get-merged-pull-request
         with:
           github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
-      # Drafts your next Release notes as Pull Requests are merged into "master"
+      # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5
-        if: "!contains(steps.get-merged-pull-request.outputs.labels, 'no-release')"
         with:
-          publish: true
+          publish: ${{ !contains(steps.get-merged-pull-request.outputs.labels, 'no-release') }}
           prerelease: false
           config-name: auto-release.yml
         env:

--- a/README.md
+++ b/README.md
@@ -240,10 +240,10 @@ Available targets:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_nat_instance_label"></a> [nat\_instance\_label](#module\_nat\_instance\_label) | cloudposse/label/null | 0.24.1 |
-| <a name="module_nat_label"></a> [nat\_label](#module\_nat\_label) | cloudposse/label/null | 0.24.1 |
-| <a name="module_private_label"></a> [private\_label](#module\_private\_label) | cloudposse/label/null | 0.24.1 |
-| <a name="module_public_label"></a> [public\_label](#module\_public\_label) | cloudposse/label/null | 0.24.1 |
+| <a name="module_nat_instance_label"></a> [nat\_instance\_label](#module\_nat\_instance\_label) | cloudposse/label/null | 0.25.0 |
+| <a name="module_nat_label"></a> [nat\_label](#module\_nat\_label) | cloudposse/label/null | 0.25.0 |
+| <a name="module_private_label"></a> [private\_label](#module\_private\_label) | cloudposse/label/null | 0.25.0 |
+| <a name="module_public_label"></a> [public\_label](#module\_public\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 | <a name="module_utils"></a> [utils](#module\_utils) | cloudposse/utils/aws | 0.8.0 |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -18,10 +18,10 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_nat_instance_label"></a> [nat\_instance\_label](#module\_nat\_instance\_label) | cloudposse/label/null | 0.24.1 |
-| <a name="module_nat_label"></a> [nat\_label](#module\_nat\_label) | cloudposse/label/null | 0.24.1 |
-| <a name="module_private_label"></a> [private\_label](#module\_private\_label) | cloudposse/label/null | 0.24.1 |
-| <a name="module_public_label"></a> [public\_label](#module\_public\_label) | cloudposse/label/null | 0.24.1 |
+| <a name="module_nat_instance_label"></a> [nat\_instance\_label](#module\_nat\_instance\_label) | cloudposse/label/null | 0.25.0 |
+| <a name="module_nat_label"></a> [nat\_label](#module\_nat\_label) | cloudposse/label/null | 0.25.0 |
+| <a name="module_private_label"></a> [private\_label](#module\_private\_label) | cloudposse/label/null | 0.25.0 |
+| <a name="module_public_label"></a> [public\_label](#module\_public\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 | <a name="module_utils"></a> [utils](#module\_utils) | cloudposse/utils/aws | 0.8.0 |
 

--- a/nat-gateway.tf
+++ b/nat-gateway.tf
@@ -1,6 +1,6 @@
 module "nat_label" {
   source  = "cloudposse/label/null"
-  version = "0.24.1"
+  version = "0.25.0"
 
   attributes = ["nat"]
 

--- a/nat-instance.tf
+++ b/nat-instance.tf
@@ -1,6 +1,6 @@
 module "nat_instance_label" {
   source  = "cloudposse/label/null"
-  version = "0.24.1"
+  version = "0.25.0"
 
   attributes = ["nat", "instance"]
 

--- a/private.tf
+++ b/private.tf
@@ -1,6 +1,6 @@
 module "private_label" {
   source  = "cloudposse/label/null"
-  version = "0.24.1"
+  version = "0.25.0"
 
   attributes = ["private"]
   tags = merge(

--- a/public.tf
+++ b/public.tf
@@ -1,6 +1,6 @@
 module "public_label" {
   source  = "cloudposse/label/null"
-  version = "0.24.1"
+  version = "0.25.0"
 
   attributes = ["public"]
   tags = merge(


### PR DESCRIPTION
## what
* Bump `null-label` module versions to `0.25.0` in order to be compatible with `context.tf`.
* Run `make github/init`

## why
* The `null-label` modules used in this module are incompatible with new labels in `context.tf` (i.e. `tenant`) which appear in `0.25.0`.
* Running `make github/init` updates GitHub Actions Workflows to the latest ones exported by [build-harness](https://github.com/cloudposse/build-harness).

## references
* N/A

