### PR TITLE
 Enable session manager and ssh by adding ssh public keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,8 +314,8 @@ Available targets:
 | <a name="input_nat_elastic_ips"></a> [nat\_elastic\_ips](#input\_nat\_elastic\_ips) | Existing Elastic IPs to attach to the NAT Gateway(s) or Instance(s) instead of creating new ones. | `list(string)` | `[]` | no |
 | <a name="input_nat_gateway_enabled"></a> [nat\_gateway\_enabled](#input\_nat\_gateway\_enabled) | Flag to enable/disable NAT Gateways to allow servers in the private subnets to access the Internet | `bool` | `true` | no |
 | <a name="input_nat_instance_enabled"></a> [nat\_instance\_enabled](#input\_nat\_instance\_enabled) | Flag to enable/disable NAT Instances to allow servers in the private subnets to access the Internet | `bool` | `false` | no |
-| <a name="input_nat_instance_profile"></a> [nat\_instance\_profile](#input\_nat\_instance\_profile) | An existing instance\_profile that need to attach to nat\_instance | `string` | `""` | no |
-| <a name="input_nat_instance_public_ssh_keys"></a> [nat\_instance\_public\_ssh\_keys](#input\_nat\_instance\_public\_ssh\_keys) | n/a | `list(string)` | `[]` | no |
+| <a name="input_nat_instance_profile"></a> [nat\_instance\_profile](#input\_nat\_instance\_profile) | An existing instance\_profile that we want to attach to nat\_instance | `string` | `""` | no |
+| <a name="input_nat_instance_public_ssh_keys"></a> [nat\_instance\_public\_ssh\_keys](#input\_nat\_instance\_public\_ssh\_keys) | SSH public keys that we want to attach to the nat instance | `list(string)` | `[]` | no |
 | <a name="input_nat_instance_type"></a> [nat\_instance\_type](#input\_nat\_instance\_type) | NAT Instance type | `string` | `"t3.micro"` | no |
 | <a name="input_private_network_acl_id"></a> [private\_network\_acl\_id](#input\_private\_network\_acl\_id) | Network ACL ID that will be added to private subnets. If empty, a new ACL will be created | `string` | `""` | no |
 | <a name="input_private_subnets_additional_tags"></a> [private\_subnets\_additional\_tags](#input\_private\_subnets\_additional\_tags) | Additional tags to be added to private subnets | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -254,6 +254,9 @@ Available targets:
 | [aws_eip.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
 | [aws_eip.nat_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
 | [aws_eip_association.nat_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip_association) | resource |
+| [aws_iam_instance_profile.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_role.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_instance.nat_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_nat_gateway.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway) | resource |
 | [aws_network_acl.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl) | resource |
@@ -269,11 +272,14 @@ Available targets:
 | [aws_security_group.nat_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.nat_instance_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.nat_instance_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.nat_instance_ssh_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_ami.nat_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_eip.nat_ips](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eip) | data source |
+| [aws_iam_policy_document.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs
@@ -308,6 +314,8 @@ Available targets:
 | <a name="input_nat_elastic_ips"></a> [nat\_elastic\_ips](#input\_nat\_elastic\_ips) | Existing Elastic IPs to attach to the NAT Gateway(s) or Instance(s) instead of creating new ones. | `list(string)` | `[]` | no |
 | <a name="input_nat_gateway_enabled"></a> [nat\_gateway\_enabled](#input\_nat\_gateway\_enabled) | Flag to enable/disable NAT Gateways to allow servers in the private subnets to access the Internet | `bool` | `true` | no |
 | <a name="input_nat_instance_enabled"></a> [nat\_instance\_enabled](#input\_nat\_instance\_enabled) | Flag to enable/disable NAT Instances to allow servers in the private subnets to access the Internet | `bool` | `false` | no |
+| <a name="input_nat_instance_profile"></a> [nat\_instance\_profile](#input\_nat\_instance\_profile) | An existing instance\_profile that need to attach to nat\_instance | `string` | `""` | no |
+| <a name="input_nat_instance_public_ssh_keys"></a> [nat\_instance\_public\_ssh\_keys](#input\_nat\_instance\_public\_ssh\_keys) | n/a | `list(string)` | `[]` | no |
 | <a name="input_nat_instance_type"></a> [nat\_instance\_type](#input\_nat\_instance\_type) | NAT Instance type | `string` | `"t3.micro"` | no |
 | <a name="input_private_network_acl_id"></a> [private\_network\_acl\_id](#input\_private\_network\_acl\_id) | Network ACL ID that will be added to private subnets. If empty, a new ACL will be created | `string` | `""` | no |
 | <a name="input_private_subnets_additional_tags"></a> [private\_subnets\_additional\_tags](#input\_private\_subnets\_additional\_tags) | Additional tags to be added to private subnets | `map(string)` | `{}` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -92,8 +92,8 @@
 | <a name="input_nat_elastic_ips"></a> [nat\_elastic\_ips](#input\_nat\_elastic\_ips) | Existing Elastic IPs to attach to the NAT Gateway(s) or Instance(s) instead of creating new ones. | `list(string)` | `[]` | no |
 | <a name="input_nat_gateway_enabled"></a> [nat\_gateway\_enabled](#input\_nat\_gateway\_enabled) | Flag to enable/disable NAT Gateways to allow servers in the private subnets to access the Internet | `bool` | `true` | no |
 | <a name="input_nat_instance_enabled"></a> [nat\_instance\_enabled](#input\_nat\_instance\_enabled) | Flag to enable/disable NAT Instances to allow servers in the private subnets to access the Internet | `bool` | `false` | no |
-| <a name="input_nat_instance_profile"></a> [nat\_instance\_profile](#input\_nat\_instance\_profile) | An existing instance\_profile that need to attach to nat\_instance | `string` | `""` | no |
-| <a name="input_nat_instance_public_ssh_keys"></a> [nat\_instance\_public\_ssh\_keys](#input\_nat\_instance\_public\_ssh\_keys) | n/a | `list(string)` | `[]` | no |
+| <a name="input_nat_instance_profile"></a> [nat\_instance\_profile](#input\_nat\_instance\_profile) | An existing instance\_profile that we want to attach to nat\_instance | `string` | `""` | no |
+| <a name="input_nat_instance_public_ssh_keys"></a> [nat\_instance\_public\_ssh\_keys](#input\_nat\_instance\_public\_ssh\_keys) | SSH public keys that we want to attach to the nat instance | `list(string)` | `[]` | no |
 | <a name="input_nat_instance_type"></a> [nat\_instance\_type](#input\_nat\_instance\_type) | NAT Instance type | `string` | `"t3.micro"` | no |
 | <a name="input_private_network_acl_id"></a> [private\_network\_acl\_id](#input\_private\_network\_acl\_id) | Network ACL ID that will be added to private subnets. If empty, a new ACL will be created | `string` | `""` | no |
 | <a name="input_private_subnets_additional_tags"></a> [private\_subnets\_additional\_tags](#input\_private\_subnets\_additional\_tags) | Additional tags to be added to private subnets | `map(string)` | `{}` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -32,6 +32,9 @@
 | [aws_eip.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
 | [aws_eip.nat_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
 | [aws_eip_association.nat_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip_association) | resource |
+| [aws_iam_instance_profile.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_role.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_instance.nat_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_nat_gateway.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway) | resource |
 | [aws_network_acl.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl) | resource |
@@ -47,11 +50,14 @@
 | [aws_security_group.nat_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.nat_instance_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.nat_instance_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.nat_instance_ssh_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_ami.nat_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_eip.nat_ips](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eip) | data source |
+| [aws_iam_policy_document.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs
@@ -86,6 +92,8 @@
 | <a name="input_nat_elastic_ips"></a> [nat\_elastic\_ips](#input\_nat\_elastic\_ips) | Existing Elastic IPs to attach to the NAT Gateway(s) or Instance(s) instead of creating new ones. | `list(string)` | `[]` | no |
 | <a name="input_nat_gateway_enabled"></a> [nat\_gateway\_enabled](#input\_nat\_gateway\_enabled) | Flag to enable/disable NAT Gateways to allow servers in the private subnets to access the Internet | `bool` | `true` | no |
 | <a name="input_nat_instance_enabled"></a> [nat\_instance\_enabled](#input\_nat\_instance\_enabled) | Flag to enable/disable NAT Instances to allow servers in the private subnets to access the Internet | `bool` | `false` | no |
+| <a name="input_nat_instance_profile"></a> [nat\_instance\_profile](#input\_nat\_instance\_profile) | An existing instance\_profile that need to attach to nat\_instance | `string` | `""` | no |
+| <a name="input_nat_instance_public_ssh_keys"></a> [nat\_instance\_public\_ssh\_keys](#input\_nat\_instance\_public\_ssh\_keys) | n/a | `list(string)` | `[]` | no |
 | <a name="input_nat_instance_type"></a> [nat\_instance\_type](#input\_nat\_instance\_type) | NAT Instance type | `string` | `"t3.micro"` | no |
 | <a name="input_private_network_acl_id"></a> [private\_network\_acl\_id](#input\_private\_network\_acl\_id) | Network ACL ID that will be added to private subnets. If empty, a new ACL will be created | `string` | `""` | no |
 | <a name="input_private_subnets_additional_tags"></a> [private\_subnets\_additional\_tags](#input\_private\_subnets\_additional\_tags) | Additional tags to be added to private subnets | `map(string)` | `{}` | no |

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,93 @@
+resource "aws_iam_instance_profile" "default" {
+  count = module.this.enabled && local.create_nat_instance_profile ? 1 : 0
+  name  = module.this.id
+  role  = aws_iam_role.default[0].name
+  tags  = module.this.tags
+}
+
+resource "aws_iam_role" "default" {
+  count = module.this.enabled && local.create_nat_instance_profile ? 1 : 0
+  name  = module.this.id
+  path  = "/"
+  tags  = module.this.tags
+
+  assume_role_policy = data.aws_iam_policy_document.default.json
+}
+
+resource "aws_iam_role_policy" "main" {
+  count  = module.this.enabled && local.create_nat_instance_profile ? 1 : 0
+  name   = module.this.id
+  role   = aws_iam_role.default[0].id
+  policy = data.aws_iam_policy_document.main.json
+}
+
+data "aws_iam_policy_document" "default" {
+  statement {
+    sid = ""
+
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+
+    effect = "Allow"
+  }
+}
+
+data "aws_iam_policy_document" "main" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ssm:DescribeAssociation",
+      "ssm:GetDeployablePatchSnapshotForInstance",
+      "ssm:GetDocument",
+      "ssm:DescribeDocument",
+      "ssm:GetManifest",
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+      "ssm:ListAssociations",
+      "ssm:ListInstanceAssociations",
+      "ssm:PutInventory",
+      "ssm:PutComplianceItems",
+      "ssm:PutConfigurePackageResult",
+      "ssm:UpdateAssociationStatus",
+      "ssm:UpdateInstanceAssociationStatus",
+      "ssm:UpdateInstanceInformation"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ec2messages:AcknowledgeMessage",
+      "ec2messages:DeleteMessage",
+      "ec2messages:FailMessage",
+      "ec2messages:GetEndpoint",
+      "ec2messages:GetMessages",
+      "ec2messages:SendReply"
+    ]
+
+    resources = ["*"]
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -71,6 +71,12 @@ variable "nat_instance_enabled" {
   default     = false
 }
 
+variable "nat_instance_profile" {
+  type        = string
+  description = "An existing instance_profile that need to attach to nat_instance"
+  default     = ""
+}
+
 variable "nat_instance_type" {
   type        = string
   description = "NAT Instance type"
@@ -135,4 +141,9 @@ variable "root_block_device_encrypted" {
   type        = bool
   default     = true
   description = "Whether to encrypt the root block device"
+}
+
+variable "nat_instance_public_ssh_keys" {
+  type    = list(string)
+  default = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -73,7 +73,7 @@ variable "nat_instance_enabled" {
 
 variable "nat_instance_profile" {
   type        = string
-  description = "An existing instance_profile that need to attach to nat_instance"
+  description = "An existing instance_profile that we want to attach to nat_instance"
   default     = ""
 }
 
@@ -144,6 +144,7 @@ variable "root_block_device_encrypted" {
 }
 
 variable "nat_instance_public_ssh_keys" {
-  type    = list(string)
-  default = []
+  type        = list(string)
+  description = "SSH public keys that we want to attach to the nat instance"
+  default     = []
 }


### PR DESCRIPTION
## what
* Enable session manager for the created nat instance. Need a proper IAM policy for users to connect
* Enable ssh to nat instance by adding ssh public keys

## why
* Enabling session manager/ssh to nat instance make it more useful because we  can use it as bastion server

## references
* https://github.com/cloudposse/terraform-aws-dynamic-subnets/issues/73 
