### PR TITLE
Availability zones must be greater than zero

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,11 @@ variable "cidr_block" {
 variable "availability_zones" {
   type        = list(string)
   description = "List of Availability Zones where subnets will be created"
+  
+  validation {
+    condition     = length(var.availability_zones) > 0
+    error_message = "Availability zones must be greater than zero."
+  }
 }
 
 variable "availability_zone_attribute_style" {

--- a/variables.tf
+++ b/variables.tf
@@ -33,7 +33,7 @@ variable "cidr_block" {
 variable "availability_zones" {
   type        = list(string)
   description = "List of Availability Zones where subnets will be created"
-  
+
   validation {
     condition     = length(var.availability_zones) > 0
     error_message = "Availability zones must be greater than zero."


### PR DESCRIPTION
## what
* Availability zones must be greater than zero

## why
* To prevent accidental applies without setting zones which results in basically a no-op or setting `var.enabled = false`.

## references
N/A

