### PR TITLE
Create public subnets only when `public_subnets_enabled` is `true`

### DIFF
--- a/public.tf
+++ b/public.tf
@@ -12,7 +12,7 @@ module "public_label" {
 }
 
 resource "aws_subnet" "public" {
-  count = local.subnet_az_count
+  count = local.public_enabled ? local.subnet_az_count : 0
 
   vpc_id            = local.vpc_id
   availability_zone = local.subnet_availability_zones[count.index]


### PR DESCRIPTION
## what
To check if create public subnet when set public_subnets_enabled false

## why
Currently, when set set public_subnets_enabled false, module still creates public subnet, according to the logic of creating private subnet, there should be a check if public_subnets_enabled is false, not creating public subnet.

## references
Slack thread: https://sweetops.slack.com/archives/CCT1E7JJY/p1652862041154429

