### PR TITLE
 fix: enable nat gateway when only private subnets are enabled

### DIFF
--- a/nat-gateway.tf
+++ b/nat-gateway.tf
@@ -11,7 +11,7 @@ resource "aws_nat_gateway" "default" {
   count = local.nat_gateway_enabled ? local.nat_count : 0
 
   allocation_id = local.nat_eip_allocations[count.index]
-  subnet_id     = aws_subnet.public[count.index].id
+  subnet_id     = local.public_enabled ? aws_subnet.public[count.index].id : aws_subnet.private[count.index].id
 
   tags = merge(
     module.nat_label.tags,


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

- Enabled Nat gateway creation when the module does not create public IPs
- Linked the nat gateway with the private subnet instead

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

- The default resource of Nat gateway will fail if public_subnets_enabled=false due to it using the first public subnet by default

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
