### PR TITLE
Allow for selectively disabling IPv6 addresses

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -135,9 +135,9 @@ locals {
   ipv6_egress_only_configured = local.ipv6_enabled && length(var.ipv6_egress_only_igw_id) > 0
 
   public4_enabled  = local.public_enabled && local.ipv4_enabled
-  public6_enabled  = local.public_enabled && local.ipv6_enabled && var.enable_public_ipv6
+  public6_enabled  = local.public_enabled && local.ipv6_enabled && var.public_ipv6_enabled
   private4_enabled = local.private_enabled && local.ipv4_enabled
-  private6_enabled = local.private_enabled && local.ipv6_enabled && var.enable_private_ipv6
+  private6_enabled = local.private_enabled && local.ipv6_enabled && var.private_ipv6_enabled
 
   public_dns64_enabled = local.public6_enabled && var.public_dns64_nat64_enabled
   # Set the default for private_dns64_enabled to true unless there is no IPv4 egress to enable it.

--- a/main.tf
+++ b/main.tf
@@ -135,7 +135,7 @@ locals {
   ipv6_egress_only_configured = local.ipv6_enabled && length(var.ipv6_egress_only_igw_id) > 0
 
   public4_enabled  = local.public_enabled && local.ipv4_enabled
-  public6_enabled  = local.public_enabled && local.ipv6_enabled
+  public6_enabled  = local.public_enabled && local.ipv6_enabled && ! var.disable_public_ipv6
   private4_enabled = local.private_enabled && local.ipv4_enabled
   private6_enabled = local.private_enabled && local.ipv6_enabled && ! var.disable_private_ipv6
 

--- a/main.tf
+++ b/main.tf
@@ -137,7 +137,7 @@ locals {
   public4_enabled  = local.public_enabled && local.ipv4_enabled
   public6_enabled  = local.public_enabled && local.ipv6_enabled
   private4_enabled = local.private_enabled && local.ipv4_enabled
-  private6_enabled = local.private_enabled && local.ipv6_enabled
+  private6_enabled = local.private_enabled && local.ipv6_enabled && ! var.disable_private_ipv6
 
   public_dns64_enabled = local.public6_enabled && var.public_dns64_nat64_enabled
   # Set the default for private_dns64_enabled to true unless there is no IPv4 egress to enable it.

--- a/main.tf
+++ b/main.tf
@@ -135,9 +135,9 @@ locals {
   ipv6_egress_only_configured = local.ipv6_enabled && length(var.ipv6_egress_only_igw_id) > 0
 
   public4_enabled  = local.public_enabled && local.ipv4_enabled
-  public6_enabled  = local.public_enabled && local.ipv6_enabled && ! var.disable_public_ipv6
+  public6_enabled  = local.public_enabled && local.ipv6_enabled && var.enable_public_ipv6
   private4_enabled = local.private_enabled && local.ipv4_enabled
-  private6_enabled = local.private_enabled && local.ipv6_enabled && ! var.disable_private_ipv6
+  private6_enabled = local.private_enabled && local.ipv6_enabled && var.enable_private_ipv6
 
   public_dns64_enabled = local.public6_enabled && var.public_dns64_nat64_enabled
   # Set the default for private_dns64_enabled to true unless there is no IPv4 egress to enable it.

--- a/variables.tf
+++ b/variables.tf
@@ -102,17 +102,17 @@ variable "ipv6_enabled" {
   nullable    = false
 }
 
-variable "disable_private_ipv6" {
+variable "enable_private_ipv6" {
   type        = bool
-  description = "Set `true` to disable IPv6 addresses in private subnets"
-  default     = false
+  description = "Set `false` to disable IPv6 addresses in private subnets"
+  default     = true
   nullable    = false
 }
 
-variable "disable_public_ipv6" {
+variable "enable_public_ipv6" {
   type        = bool
   description = "Set `true` to disable IPv6 addresses in public subnets"
-  default     = false
+  default     = true
   nullable    = false
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -102,14 +102,14 @@ variable "ipv6_enabled" {
   nullable    = false
 }
 
-variable "enable_private_ipv6" {
+variable "private_ipv6_enabled" {
   type        = bool
   description = "Set `false` to disable IPv6 addresses in private subnets"
   default     = true
   nullable    = false
 }
 
-variable "enable_public_ipv6" {
+variable "public_ipv6_enabled" {
   type        = bool
   description = "Set `false` to disable IPv6 addresses in public subnets"
   default     = true

--- a/variables.tf
+++ b/variables.tf
@@ -111,7 +111,7 @@ variable "enable_private_ipv6" {
 
 variable "enable_public_ipv6" {
   type        = bool
-  description = "Set `true` to disable IPv6 addresses in public subnets"
+  description = "Set `false` to disable IPv6 addresses in public subnets"
   default     = true
   nullable    = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -109,6 +109,13 @@ variable "disable_private_ipv6" {
   nullable    = false
 }
 
+variable "disable_public_ipv6" {
+  type        = bool
+  description = "Set `true` to disable IPv6 addresses in public subnets"
+  default     = false
+  nullable    = false
+}
+
 variable "ipv4_cidr_block" {
   type        = list(string)
   description = <<-EOT

--- a/variables.tf
+++ b/variables.tf
@@ -102,6 +102,13 @@ variable "ipv6_enabled" {
   nullable    = false
 }
 
+variable "disable_private_ipv6" {
+  type        = bool
+  description = "Set `true` to disable IPv6 addresses in private subnets"
+  default     = false
+  nullable    = false
+}
+
 variable "ipv4_cidr_block" {
   type        = list(string)
   description = <<-EOT


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
Allow for selectively disabling IPv6 addresses
## why
We don't want IPv6 addresses in our private subnets, only public subnets. This PR lets that happen.

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
