### PR TITLE
feat: use vpc tags to get vpc id

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -271,6 +271,8 @@ data "aws_availability_zones" "default" {
 data "aws_vpc" "default" {
   count = local.need_vpc_data ? 1 : 0
 
+  tags = var.vpc_id
+
   id = local.vpc_id
 }
 

--- a/main.tf
+++ b/main.tf
@@ -271,9 +271,9 @@ data "aws_availability_zones" "default" {
 data "aws_vpc" "default" {
   count = local.need_vpc_data ? 1 : 0
 
-  tags = var.vpc_id
-
   id = var.vpc_id
+
+  tags = var.vpc_id
 }
 
 data "aws_eip" "nat" {

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ locals {
   nat64_cidr = "64:ff9b::/96"
 
   # In case we later decide to compute it
-  vpc_id = var.vpc_id
+  vpc_id = one(data.aws_vpc.default[*].id)
 
   #####################################################################
   ## Determine the set of availability zones in which to deploy subnets
@@ -273,7 +273,7 @@ data "aws_vpc" "default" {
 
   tags = var.vpc_id
 
-  id = local.vpc_id
+  id = var.vpc_id
 }
 
 data "aws_eip" "nat" {

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,6 @@ locals {
   # The RFC 6052 "well known" NAT64 CIDR
   nat64_cidr = "64:ff9b::/96"
 
-  # In case we later decide to compute it
   vpc_id = one(data.aws_vpc.default[*].id)
 
   #####################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "vpc_id" {
   default     = null
 }
 
+variable "vpc_tags" {
+  type        = map(string)
+  description = "VPC tags to get the VPC ID where subnets will be created"
+  default     = null
+}
+
 variable "igw_id" {
   type        = list(string)
   description = <<-EOT

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,7 @@
 variable "vpc_id" {
   type        = string
   description = "VPC ID where subnets will be created (e.g. `vpc-aceb2723`)"
+  default     = null
 }
 
 variable "igw_id" {


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- feat: use vpc tags to get vpc id

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- Id like to create subnets off of an existing vpc using a component based off of this module without hard coding the vpc id
- By allowing us to use tags, we can use tags such as the following to get the vpc id

```yaml
components: 
  terraform:
    vpc/example:
      vars:
        # ...

    vpc/example/dynamic-subnets/db:
      metadata:
        component: dynamic-subnets
      vars:
        vpc_tags:
          Name: org-ue1-prod-vpc
          Environment: ue1
          Stage: prod
        # ...
```

Edit: Without the pr, we can read remote state using this without supplying tags

```yaml
    vpc/example/dynamic-subnets/db:
      metadata:
        component: dynamic-subnets
      vars:
        vpc_id: !terraform.output vpc/example vpc_id
```

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- https://sweetops.slack.com/archives/C031919U8A0/p1736462794326679?thread_ts=1736462794.326679&cid=C031919U8A0
- https://github.com/cloudposse-terraform-components/aws-vpc/tree/main/src#output_vpc_id
