### PR TITLE
chore(example): update example/complete usage of tags to replace `subnet_type_tag_key`

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -29,7 +29,9 @@ module "subnets" {
   route_create_timeout    = "5m"
   route_delete_timeout    = "10m"
 
-  subnet_type_tag_key = "cpco.io/subnet/type"
+  public_subnets_additional_tags  = { format("%s/subnet/type", module.this.id) = "public" }
+  private_subnets_additional_tags = { format("%s/subnet/type", module.this.id) = "private" }
+
 
   subnets_per_az_count = var.subnets_per_az_count
   subnets_per_az_names = var.subnets_per_az_names

--- a/examples/multiple-subnets-per-az/main.tf
+++ b/examples/multiple-subnets-per-az/main.tf
@@ -27,7 +27,8 @@ module "subnets" {
   route_create_timeout    = "5m"
   route_delete_timeout    = "10m"
 
-  subnet_type_tag_key = "cpco.io/subnet/type"
+  public_subnets_additional_tags  = { format("%s/subnet/type", module.this.id) = "public" }
+  private_subnets_additional_tags = { format("%s/subnet/type", module.this.id) = "private" }
 
   subnets_per_az_count = var.subnets_per_az_count
   subnets_per_az_names = var.subnets_per_az_names

--- a/examples/nacls/main.tf
+++ b/examples/nacls/main.tf
@@ -33,7 +33,8 @@ module "subnets" {
   route_create_timeout    = "5m"
   route_delete_timeout    = "10m"
 
-  subnet_type_tag_key = "cpco.io/subnet/type"
+  public_subnets_additional_tags  = { format("%s/subnet/type", module.this.id) = "public" }
+  private_subnets_additional_tags = { format("%s/subnet/type", module.this.id) = "private" }
 
   subnets_per_az_count = var.subnets_per_az_count
   subnets_per_az_names = var.subnets_per_az_names


### PR DESCRIPTION
## what

Update the example root modules to use `public_subnets_additional_tags` and `private_subnets_additional_tags`

## why

`subnet_type_tag_key` is deprecated. 
<img width="779" height="415" alt="image" src="https://github.com/user-attachments/assets/ba564747-4f41-4344-8e95-fde8f13247c1" />