### PR TITLE
feat: add nat_gateway_private_ips output

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,7 @@ but in conjunction with this module.
 | <a name="output_named_public_subnets_stats_map"></a> [named\_public\_subnets\_stats\_map](#output\_named\_public\_subnets\_stats\_map) | Map of subnet names (specified in `public_subnets_per_az_names` or `subnets_per_az_names` variable) to lists of objects with each object having four items: AZ, public subnet ID, public route table ID, NAT Gateway ID (the NAT Gateway in this public subnet, if any) |
 | <a name="output_nat_eip_allocation_ids"></a> [nat\_eip\_allocation\_ids](#output\_nat\_eip\_allocation\_ids) | Elastic IP allocations in use by NAT |
 | <a name="output_nat_gateway_ids"></a> [nat\_gateway\_ids](#output\_nat\_gateway\_ids) | IDs of the NAT Gateways created |
+| <a name="output_nat_gateway_private_ips"></a> [nat\_gateway\_private\_ips](#output\_nat\_gateway\_private\_ips) | Private IP addresses of the NAT Gateways |
 | <a name="output_nat_gateway_public_ips"></a> [nat\_gateway\_public\_ips](#output\_nat\_gateway\_public\_ips) | DEPRECATED: use `nat_ips` instead. Public IPv4 IP addresses in use by NAT. |
 | <a name="output_nat_instance_ami_id"></a> [nat\_instance\_ami\_id](#output\_nat\_instance\_ami\_id) | ID of AMI used by NAT instance |
 | <a name="output_nat_instance_ids"></a> [nat\_instance\_ids](#output\_nat\_instance\_ids) | IDs of the NAT Instances created |

--- a/outputs.tf
+++ b/outputs.tf
@@ -78,6 +78,11 @@ output "nat_gateway_ids" {
   value       = aws_nat_gateway.default[*].id
 }
 
+output "nat_gateway_private_ips" {
+  description = "Private IP addresses of the NAT Gateways"
+  value       = aws_nat_gateway.default[*].private_ip
+}
+
 output "nat_instance_ids" {
   description = "IDs of the NAT Instances created"
   value       = aws_instance.nat_instance[*].id


### PR DESCRIPTION
## what

- Add `nat_gateway_private_ips` output to expose private IP addresses of NAT Gateways
- Follows the existing pattern used for other NAT Gateway attributes

## why

- Users need access to NAT Gateway private IPs for internal networking configurations (e.g., security groups, route debugging)
- Enables use of these IPs as inputs to other components

## references

- Requested in feature request: NAT gateway private IPs output support