### PR TITLE
fix(validation): safely handle null values for *_subnets_per_az_count using can()

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -517,7 +517,7 @@ variable "public_subnets_per_az_count" {
     EOT
   default     = null
   validation {
-    condition     = var.public_subnets_per_az_count == null || var.public_subnets_per_az_count > 0
+    condition     = var.public_subnets_per_az_count == null || can(var.public_subnets_per_az_count > 0)
     error_message = "The `public_subnets_per_az_count` value must be greater than 0 or null."
   }
 }
@@ -543,7 +543,7 @@ variable "private_subnets_per_az_count" {
     EOT
   default     = null
   validation {
-    condition     = var.private_subnets_per_az_count == null || var.private_subnets_per_az_count > 0
+    condition     = var.private_subnets_per_az_count == null || can(var.private_subnets_per_az_count > 0)
     error_message = "The `private_subnets_per_az_count` value must be greater than 0 or null."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -517,7 +517,7 @@ variable "public_subnets_per_az_count" {
     EOT
   default     = null
   validation {
-    condition     = var.public_subnets_per_az_count == null || can(var.public_subnets_per_az_count > 0)
+    condition     = var.public_subnets_per_az_count == null || try(var.public_subnets_per_az_count > 0, false)
     error_message = "The `public_subnets_per_az_count` value must be greater than 0 or null."
   }
 }
@@ -543,7 +543,7 @@ variable "private_subnets_per_az_count" {
     EOT
   default     = null
   validation {
-    condition     = var.private_subnets_per_az_count == null || can(var.private_subnets_per_az_count > 0)
+    condition     = var.private_subnets_per_az_count == null || try(var.private_subnets_per_az_count > 0, false)
     error_message = "The `private_subnets_per_az_count` value must be greater than 0 or null."
   }
 }


### PR DESCRIPTION
## What
Fixes validation logic for `private_subnets_per_az_count` and `public_subnets_per_az_count` by wrapping numeric comparison in `can()`.

## Why
Terraform 1.5+ may evaluate expressions differently when values are null.
Using `can()` prevents invalid comparisons when the variable is null.

## References
Fixes #230