### PR TITLE
Support regional NAT gateway

### DIFF
--- a/examples/regional-nat-gateway/README.md
+++ b/examples/regional-nat-gateway/README.md
@@ -1,0 +1,84 @@
+# Regional NAT Gateway Example
+
+This example demonstrates how to use the Regional NAT Gateway feature, which was introduced by AWS to simplify network architecture and provide automatic high availability across Availability Zones.
+
+## Key Features of Regional NAT Gateway
+
+- **Simplified Architecture**: Single NAT Gateway ID that automatically expands across all AZs
+- **No Public Subnets Required**: Regional NAT Gateways don't need to be placed in public subnets, enhancing security
+- **Automatic High Availability**: Automatically expands and contracts with your workload footprint
+- **Higher Limits**: Supports up to 32 IP addresses per AZ (vs 8 for zonal NAT gateways)
+- **Cost Optimization**: Simpler to manage and can reduce operational overhead
+
+## Configuration
+
+This example creates:
+- A VPC with IPv4 CIDR block
+- Private subnets across multiple availability zones
+- A single Regional NAT Gateway that automatically provides NAT services across all AZs
+- Route tables configured to route traffic through the Regional NAT Gateway
+
+## Key Differences from Zonal NAT Gateway
+
+### Zonal NAT Gateway (Traditional)
+```hcl
+module "subnets" {
+  source = "cloudposse/dynamic-subnets/aws"
+  
+  nat_gateway_enabled           = true
+  nat_gateway_availability_mode = "zonal"  # or omit (default)
+  public_subnets_enabled        = true     # Required for zonal NAT
+  private_subnets_enabled       = true
+  # Creates one NAT per AZ in public subnets
+}
+```
+
+### Regional NAT Gateway (New)
+```hcl
+module "subnets" {
+  source = "cloudposse/dynamic-subnets/aws"
+  
+  nat_gateway_enabled           = true
+  nat_gateway_availability_mode = "regional"
+  public_subnets_enabled        = false    # Not required for regional NAT
+  private_subnets_enabled       = true
+  # Creates one Regional NAT that spans all AZs
+}
+```
+
+## Usage
+
+To run this example:
+
+```bash
+terraform init
+terraform plan -var-file=fixtures.us-east-2.tfvars
+terraform apply -var-file=fixtures.us-east-2.tfvars
+```
+
+## Important Notes
+
+1. **Regional NAT Gateways only support public connectivity** - they cannot be used for private NAT use cases
+2. **Automatic expansion takes up to 60 minutes** - when you launch resources in a new AZ, the Regional NAT Gateway may take up to 60 minutes to expand to that zone
+3. **Internet Gateway is required** - Regional NAT Gateways need an Internet Gateway in the VPC
+4. **Backward compatible** - Existing configurations continue to work with the default `zonal` mode
+
+## When to Use Regional NAT Gateway
+
+Consider using Regional NAT Gateways for:
+- New deployments where you want simplified architecture
+- Workloads that dynamically scale across AZs
+- Environments where you want to minimize public subnet exposure
+- Applications that can tolerate the 60-minute expansion window
+
+Use Zonal NAT Gateways for:
+- Private NAT use cases (connectivity_type = "private")
+- Workloads requiring immediate NAT availability in new AZs
+- Existing deployments where migration complexity outweighs benefits
+
+## Outputs
+
+- `nat_gateway_ids` - The ID of the Regional NAT Gateway
+- `nat_gateway_route_table_id` - The automatically created route table for the Regional NAT Gateway
+- `nat_gateway_regional_addresses` - Information about IP addresses and network interfaces across AZs
+- `private_subnet_ids` - IDs of the private subnets created

--- a/examples/regional-nat-gateway/context.tf
+++ b/examples/regional-nat-gateway/context.tf
@@ -1,0 +1,13 @@
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  namespace   = var.namespace
+  environment = var.environment
+  stage       = var.stage
+  name        = var.name
+  delimiter   = var.delimiter
+  attributes  = var.attributes
+  tags        = var.tags
+  enabled     = var.enabled
+}

--- a/examples/regional-nat-gateway/fixtures.us-east-2.tfvars
+++ b/examples/regional-nat-gateway/fixtures.us-east-2.tfvars
@@ -1,0 +1,6 @@
+region             = "us-east-2"
+availability_zones = ["us-east-2a", "us-east-2b", "us-east-2c"]
+
+namespace = "eg"
+stage     = "test"
+name      = "regional-nat"

--- a/examples/regional-nat-gateway/main.tf
+++ b/examples/regional-nat-gateway/main.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  region = var.region
+}
+
+module "vpc" {
+  source  = "cloudposse/vpc/aws"
+  version = "3.0.0"
+
+  ipv4_primary_cidr_block = "172.16.0.0/16"
+
+  context = module.this.context
+}
+
+module "subnets" {
+  source = "../../"
+
+  availability_zones              = var.availability_zones
+  vpc_id                          = module.vpc.vpc_id
+  igw_id                          = [module.vpc.igw_id]
+  ipv4_cidr_block                 = [module.vpc.vpc_cidr_block]
+  nat_gateway_enabled             = true
+  nat_gateway_availability_mode   = "regional"
+  public_subnets_enabled          = false # Regional NAT doesn't require public subnets
+  private_subnets_enabled         = true
+  max_subnet_count                = 3
+
+  context = module.this.context
+}

--- a/examples/regional-nat-gateway/outputs.tf
+++ b/examples/regional-nat-gateway/outputs.tf
@@ -1,0 +1,24 @@
+output "private_subnet_ids" {
+  description = "IDs of the created private subnets"
+  value       = module.subnets.private_subnet_ids
+}
+
+output "nat_gateway_ids" {
+  description = "IDs of the NAT Gateways created"
+  value       = module.subnets.nat_gateway_ids
+}
+
+output "nat_gateway_route_table_id" {
+  description = "ID of the automatically created route table for Regional NAT Gateway"
+  value       = module.subnets.nat_gateway_route_table_id
+}
+
+output "nat_gateway_regional_addresses" {
+  description = "Information about IP addresses and network interfaces for Regional NAT Gateway"
+  value       = module.subnets.nat_gateway_regional_addresses
+}
+
+output "availability_zones" {
+  description = "List of Availability Zones where subnets were created"
+  value       = module.subnets.availability_zones
+}

--- a/examples/regional-nat-gateway/variables.tf
+++ b/examples/regional-nat-gateway/variables.tf
@@ -1,0 +1,54 @@
+variable "region" {
+  type        = string
+  description = "AWS Region"
+}
+
+variable "availability_zones" {
+  type        = list(string)
+  description = "List of availability zones"
+}
+
+variable "namespace" {
+  type        = string
+  description = "Namespace, which could be your organization name or abbreviation"
+}
+
+variable "environment" {
+  type        = string
+  default     = ""
+  description = "Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  description = "Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  description = "Solution name, e.g. 'app' or 'jenkins'"
+}
+
+variable "delimiter" {
+  type        = string
+  default     = "-"
+  description = "Delimiter to be used between namespace, environment, stage, name and attributes"
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = "Additional attributes (e.g. `1`)"
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`"
+}
+
+variable "enabled" {
+  type        = bool
+  default     = true
+  description = "Set to false to prevent the module from creating any resources"
+}

--- a/examples/regional-nat-gateway/versions.tf
+++ b/examples/regional-nat-gateway/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.24"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -186,8 +186,12 @@ locals {
   public_route_table_ids     = local.create_public_route_tables ? aws_route_table.public[*].id : var.public_route_table_ids
 
   private_route_table_enabled = local.private_enabled && var.private_route_table_enabled
-  private_route_table_count   = local.private_route_table_enabled ? local.private_subnet_az_count : 0
-  private_route_table_ids     = local.private_route_table_enabled ? aws_route_table.private[*].id : []
+  # For regional NAT gateway, use a single shared route table since all subnets route to the same NAT
+  # For zonal NAT gateway or NAT instance, use one route table per subnet (each routes to different NAT)
+  private_route_table_count = local.private_route_table_enabled ? (
+    var.nat_gateway_availability_mode == "regional" && local.nat_gateway_enabled ? 1 : local.private_subnet_az_count
+  ) : 0
+  private_route_table_ids = local.private_route_table_enabled ? aws_route_table.private[*].id : []
 
   # public and private network ACLs
   # Support deprecated var.public_network_acl_id
@@ -225,7 +229,8 @@ locals {
   # Calculate which public subnet indices to use for NAT placement
   # For each AZ (up to max_nats), and for each requested subnet index within that AZ,
   # calculate the global subnet index in the flattened aws_subnet.public list
-  nat_gateway_public_subnet_indices = local.nat_gateway_useful ? flatten([
+  # Only used for zonal NAT gateways; regional NAT gateways don't need subnet placement
+  nat_gateway_public_subnet_indices = local.nat_gateway_useful && var.nat_gateway_availability_mode == "zonal" ? flatten([
     for az_idx in range(min(local.vpc_az_count, var.max_nats)) : [
       for subnet_idx in local.nat_gateway_resolved_indices :
       az_idx * local.public_subnets_per_az_count + subnet_idx
@@ -234,7 +239,8 @@ locals {
   ]) : []
 
   # NAT count is the number of NAT devices to create (based on AZs and indices requested)
-  nat_count = length(local.nat_gateway_public_subnet_indices)
+  # For regional mode, we create 1 NAT gateway; for zonal mode, we create based on subnet placement
+  nat_count = var.nat_gateway_availability_mode == "regional" ? (local.nat_gateway_useful ? 1 : 0) : length(local.nat_gateway_public_subnet_indices)
 
   # How many NATs are created per AZ
   nats_per_az = local.nat_count > 0 ? length(local.nat_gateway_resolved_indices) : 0
@@ -297,9 +303,13 @@ locals {
   nat_gateway_enabled  = local.nat_gateway_useful && local.nat_gateway_setting
   nat_instance_enabled = local.nat_instance_useful && local.nat_instance_setting
   nat_enabled          = local.nat_gateway_enabled || local.nat_instance_enabled
-  need_nat_eips        = local.nat_enabled && length(var.nat_elastic_ips) == 0
-  need_nat_eip_data    = local.nat_enabled && length(var.nat_elastic_ips) > 0
-  nat_eip_allocations  = local.nat_enabled ? (local.need_nat_eips ? aws_eip.default[*].id : data.aws_eip.nat[*].id) : []
+  # Regional NAT gateways in auto mode don't need EIPs (AWS manages them automatically)
+  # Only zonal NAT gateways and NAT instances need EIPs
+  need_nat_eips     = local.nat_enabled && var.nat_gateway_availability_mode == "zonal" && length(var.nat_elastic_ips) == 0
+  need_nat_eip_data = local.nat_enabled && var.nat_gateway_availability_mode == "zonal" && length(var.nat_elastic_ips) > 0
+  nat_eip_allocations = (local.nat_enabled && var.nat_gateway_availability_mode == "zonal") ? (
+    local.need_nat_eips ? aws_eip.default[*].id : data.aws_eip.nat[*].id
+  ) : []
 
   need_nat_ami_id     = local.nat_instance_enabled && length(var.nat_instance_ami_id) == 0
   nat_instance_ami_id = local.need_nat_ami_id ? data.aws_ami.nat_instance[0].id : try(var.nat_instance_ami_id[0], "")
@@ -338,13 +348,45 @@ locals {
   }
 
   # Create a map from public subnet ID to NAT Gateway ID (for public subnets that have NAT Gateways)
-  public_subnet_to_nat_gateway_map = { for nat in aws_nat_gateway.default : nat.subnet_id => nat.id }
+  # Only applicable for zonal NAT gateways
+  public_subnet_to_nat_gateway_map = var.nat_gateway_availability_mode == "zonal" ? {
+    for nat in aws_nat_gateway.default : nat.subnet_id => nat.id
+  } : {}
 
   # Create a map from private subnet ID to NAT Gateway ID (the NAT that the private subnet routes to)
-  private_subnet_to_nat_gateway_map = local.nat_gateway_enabled && local.private4_enabled ? {
-    for idx, subnet in aws_subnet.private :
-    subnet.id => aws_nat_gateway.default[local.private_route_table_to_nat_map[idx]].id
-  } : {}
+  # For regional mode, all private subnets route to the same regional NAT gateway
+  # For zonal mode, each private subnet routes to a NAT in its own AZ
+  private_subnet_to_nat_gateway_map = local.nat_gateway_enabled && local.private4_enabled ? (
+    var.nat_gateway_availability_mode == "regional" ? {
+      for subnet in aws_subnet.private :
+      subnet.id => aws_nat_gateway.regional[0].id
+      } : {
+      for idx, subnet in aws_subnet.private :
+      subnet.id => aws_nat_gateway.default[local.private_route_table_to_nat_map[idx]].id
+    }
+  ) : {}
+
+  # Compute NAT Gateway IDs for private route tables
+  # For regional mode: single route table points to the regional NAT
+  # For zonal mode: each route table points to the NAT in the same AZ
+  nat_gateway_id_for_route = local.nat_gateway_enabled && local.private4_enabled ? (
+    var.nat_gateway_availability_mode == "regional" ? [
+      aws_nat_gateway.regional[0].id
+      ] : [
+      for i in range(local.private_route_table_count) : aws_nat_gateway.default[local.private_route_table_to_nat_map[i]].id
+    ]
+  ) : []
+
+  # Compute NAT Gateway IDs for public route tables (NAT64)
+  # For regional mode: all routes point to the single regional NAT
+  # For zonal mode: routes point to the NAT in the same AZ
+  nat_gateway_id_for_public_route = local.nat_gateway_enabled && local.public_dns64_enabled ? (
+    var.nat_gateway_availability_mode == "regional" ? [
+      for i in range(local.public_route_table_count) : aws_nat_gateway.regional[0].id
+      ] : [
+      for i in range(local.public_route_table_count) : aws_nat_gateway.default[local.public_route_table_to_nat_map[i]].id
+    ]
+  ) : []
 
   named_private_subnets_stats_map = { for i, s in local.private_subnets_per_az_names : s => (
     [

--- a/main.tf
+++ b/main.tf
@@ -189,7 +189,7 @@ locals {
   # For regional NAT gateway, use a single shared route table since all subnets route to the same NAT
   # For zonal NAT gateway or NAT instance, use one route table per subnet (each routes to different NAT)
   private_route_table_count = local.private_route_table_enabled ? (
-    var.nat_gateway_availability_mode == "regional" && local.nat_gateway_enabled ? 1 : local.private_subnet_az_count
+    local.regional_nat_gateway_useful ? 1 : local.private_subnet_az_count
   ) : 0
   private_route_table_ids = local.private_route_table_enabled ? aws_route_table.private[*].id : []
 
@@ -203,6 +203,10 @@ locals {
   # An AWS NAT instance does not perform NAT64, and we choose not to try to support NAT64 via NAT instances at this time.
   nat_instance_useful = local.private4_enabled
   nat_gateway_useful  = local.nat_instance_useful || local.public_dns64_enabled || local.private_dns64_enabled
+
+  # Zonal versus Regional NAT gateways
+  zonal_nat_gateway_useful    = local.nat_gateway_useful && var.nat_gateway_availability_mode == "zonal"
+  regional_nat_gateway_useful = local.nat_gateway_useful && var.nat_gateway_availability_mode == "regional"
 
   # Convert subnet names to indices if names were specified
   # Creates a map of subnet name -> index for easy lookup
@@ -230,7 +234,7 @@ locals {
   # For each AZ (up to max_nats), and for each requested subnet index within that AZ,
   # calculate the global subnet index in the flattened aws_subnet.public list
   # Only used for zonal NAT gateways; regional NAT gateways don't need subnet placement
-  nat_gateway_public_subnet_indices = local.nat_gateway_useful && var.nat_gateway_availability_mode == "zonal" ? flatten([
+  nat_gateway_public_subnet_indices = local.zonal_nat_gateway_useful ? flatten([
     for az_idx in range(min(local.vpc_az_count, var.max_nats)) : [
       for subnet_idx in local.nat_gateway_resolved_indices :
       az_idx * local.public_subnets_per_az_count + subnet_idx
@@ -305,9 +309,9 @@ locals {
   nat_enabled          = local.nat_gateway_enabled || local.nat_instance_enabled
   # Regional NAT gateways in auto mode don't need EIPs (AWS manages them automatically)
   # Only zonal NAT gateways and NAT instances need EIPs
-  need_nat_eips     = local.nat_enabled && var.nat_gateway_availability_mode == "zonal" && length(var.nat_elastic_ips) == 0
-  need_nat_eip_data = local.nat_enabled && var.nat_gateway_availability_mode == "zonal" && length(var.nat_elastic_ips) > 0
-  nat_eip_allocations = (local.nat_enabled && var.nat_gateway_availability_mode == "zonal") ? (
+  need_nat_eips     = local.zonal_nat_gateway_useful && length(var.nat_elastic_ips) == 0
+  need_nat_eip_data = local.zonal_nat_gateway_useful && length(var.nat_elastic_ips) > 0
+  nat_eip_allocations = local.zonal_nat_gateway_useful ? (
     local.need_nat_eips ? aws_eip.default[*].id : data.aws_eip.nat[*].id
   ) : []
 
@@ -349,7 +353,7 @@ locals {
 
   # Create a map from public subnet ID to NAT Gateway ID (for public subnets that have NAT Gateways)
   # Only applicable for zonal NAT gateways
-  public_subnet_to_nat_gateway_map = var.nat_gateway_availability_mode == "zonal" ? {
+  public_subnet_to_nat_gateway_map = local.zonal_nat_gateway_useful ? {
     for nat in aws_nat_gateway.default : nat.subnet_id => nat.id
   } : {}
 

--- a/nat-gateway.tf
+++ b/nat-gateway.tf
@@ -9,7 +9,7 @@ module "nat_label" {
 
 # Zonal NAT Gateways (traditional mode - one per AZ in public subnets)
 resource "aws_nat_gateway" "default" {
-  count = local.nat_gateway_enabled && var.nat_gateway_availability_mode == "zonal" ? local.nat_count : 0
+  count = local.zonal_nat_gateway_useful ? local.nat_count : 0
 
   allocation_id = local.nat_eip_allocations[count.index]
   subnet_id     = aws_subnet.public[local.nat_gateway_public_subnet_indices[count.index]].id
@@ -33,7 +33,7 @@ resource "aws_nat_gateway" "default" {
 
 # Regional NAT Gateway (automatic multi-AZ expansion)
 resource "aws_nat_gateway" "regional" {
-  count = local.nat_gateway_enabled && var.nat_gateway_availability_mode == "regional" ? 1 : 0
+  count = local.regional_nat_gateway_useful ? 1 : 0
 
   vpc_id            = local.vpc_id
   availability_mode = "regional"
@@ -47,13 +47,6 @@ resource "aws_nat_gateway" "regional" {
   )
 
   depends_on = [aws_eip_association.nat_instance]
-
-  lifecycle {
-    precondition {
-      condition     = var.nat_gateway_availability_mode != "regional" || local.igw_configured
-      error_message = "Regional NAT Gateways require an Internet Gateway. Please provide `igw_id`."
-    }
-  }
 }
 
 # If private IPv4 subnets and NAT Gateway are both enabled, create a

--- a/nat-gateway.tf
+++ b/nat-gateway.tf
@@ -7,8 +7,9 @@ module "nat_label" {
   context = module.this.context
 }
 
+# Zonal NAT Gateways (traditional mode - one per AZ in public subnets)
 resource "aws_nat_gateway" "default" {
-  count = local.nat_gateway_enabled ? local.nat_count : 0
+  count = local.nat_gateway_enabled && var.nat_gateway_availability_mode == "zonal" ? local.nat_count : 0
 
   allocation_id = local.nat_eip_allocations[count.index]
   subnet_id     = aws_subnet.public[local.nat_gateway_public_subnet_indices[count.index]].id
@@ -30,14 +31,39 @@ resource "aws_nat_gateway" "default" {
   }
 }
 
+# Regional NAT Gateway (automatic multi-AZ expansion)
+resource "aws_nat_gateway" "regional" {
+  count = local.nat_gateway_enabled && var.nat_gateway_availability_mode == "regional" ? 1 : 0
+
+  vpc_id            = local.vpc_id
+  availability_mode = "regional"
+  connectivity_type = "public"
+
+  tags = merge(
+    module.nat_label.tags,
+    {
+      "Name" = format("%s%s%s", module.nat_label.id, local.delimiter, "regional")
+    }
+  )
+
+  depends_on = [aws_eip_association.nat_instance]
+
+  lifecycle {
+    precondition {
+      condition     = var.nat_gateway_availability_mode != "regional" || local.igw_configured
+      error_message = "Regional NAT Gateways require an Internet Gateway. Please provide `igw_id`."
+    }
+  }
+}
+
 # If private IPv4 subnets and NAT Gateway are both enabled, create a
 # default route from private subnet to NAT Gateway in each subnet
-# Each private subnet routes to a NAT in its own AZ
+# Each private subnet routes to a NAT in its own AZ (zonal mode) or to the regional NAT (regional mode)
 resource "aws_route" "nat4" {
   count = local.nat_gateway_enabled && local.private4_enabled ? local.private_route_table_count : 0
 
   route_table_id         = local.private_route_table_ids[count.index]
-  nat_gateway_id         = aws_nat_gateway.default[local.private_route_table_to_nat_map[count.index]].id
+  nat_gateway_id         = local.nat_gateway_id_for_route[count.index]
   destination_cidr_block = "0.0.0.0/0"
   depends_on             = [aws_route_table.private]
 
@@ -49,12 +75,12 @@ resource "aws_route" "nat4" {
 
 # If private IPv6 subnet needs NAT64 and NAT Gateway is enabled, create a
 # NAT64 route from private subnet to NAT Gateway in each subnet
-# Each private subnet routes to a NAT in its own AZ
+# Each private subnet routes to a NAT in its own AZ (zonal mode) or to the regional NAT (regional mode)
 resource "aws_route" "private_nat64" {
   count = local.nat_gateway_enabled && local.private_dns64_enabled ? local.private_route_table_count : 0
 
   route_table_id              = local.private_route_table_ids[count.index]
-  nat_gateway_id              = aws_nat_gateway.default[local.private_route_table_to_nat_map[count.index]].id
+  nat_gateway_id              = local.nat_gateway_id_for_route[count.index]
   destination_ipv6_cidr_block = local.nat64_cidr
   depends_on                  = [aws_route_table.private]
 
@@ -66,12 +92,12 @@ resource "aws_route" "private_nat64" {
 
 # If public IPv6 subnet needs NAT64 and NAT Gateway is enabled, create a
 # NAT64 route from public subnet to NAT Gateway in each subnet
-# Each public subnet routes to a NAT in its own AZ
+# Each public subnet routes to a NAT in its own AZ (zonal mode) or to the regional NAT (regional mode)
 resource "aws_route" "public_nat64" {
   count = local.nat_gateway_enabled && local.public_dns64_enabled ? local.public_route_table_count : 0
 
   route_table_id              = local.public_route_table_ids[count.index]
-  nat_gateway_id              = aws_nat_gateway.default[local.public_route_table_to_nat_map[count.index]].id
+  nat_gateway_id              = local.nat_gateway_id_for_public_route[count.index]
   destination_ipv6_cidr_block = local.nat64_cidr
   depends_on                  = [aws_route_table.public]
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -75,12 +75,22 @@ output "private_network_acl_id" {
 
 output "nat_gateway_ids" {
   description = "IDs of the NAT Gateways created"
-  value       = aws_nat_gateway.default[*].id
+  value       = var.nat_gateway_availability_mode == "regional" ? aws_nat_gateway.regional[*].id : aws_nat_gateway.default[*].id
 }
 
 output "nat_gateway_private_ips" {
-  description = "Private IP addresses of the NAT Gateways"
-  value       = aws_nat_gateway.default[*].private_ip
+  description = "Private IP addresses of the NAT Gateways (zonal mode only)"
+  value       = var.nat_gateway_availability_mode == "zonal" ? aws_nat_gateway.default[*].private_ip : []
+}
+
+output "nat_gateway_route_table_id" {
+  description = "ID of the automatically created route table for Regional NAT Gateway (regional mode only)"
+  value       = var.nat_gateway_availability_mode == "regional" && local.nat_gateway_enabled ? try(aws_nat_gateway.regional[0].route_table_id, null) : null
+}
+
+output "nat_gateway_regional_addresses" {
+  description = "Information about IP addresses and network interfaces for Regional NAT Gateway (regional mode only)"
+  value       = var.nat_gateway_availability_mode == "regional" && local.nat_gateway_enabled ? try(aws_nat_gateway.regional[0].regional_nat_gateway_address, []) : []
 }
 
 output "nat_instance_ids" {
@@ -94,13 +104,13 @@ output "nat_instance_ami_id" {
 }
 
 output "nat_ips" {
-  description = "Elastic IP Addresses in use by NAT"
-  value       = local.need_nat_eip_data ? var.nat_elastic_ips : aws_eip.default[*].public_ip
+  description = "Elastic IP Addresses in use by NAT (zonal mode only; regional mode manages IPs automatically)"
+  value       = var.nat_gateway_availability_mode == "zonal" && local.need_nat_eip_data ? var.nat_elastic_ips : (var.nat_gateway_availability_mode == "zonal" ? aws_eip.default[*].public_ip : [])
 }
 
 output "nat_eip_allocation_ids" {
-  description = "Elastic IP allocations in use by NAT"
-  value       = local.nat_eip_allocations
+  description = "Elastic IP allocations in use by NAT (zonal mode only; regional mode manages IPs automatically)"
+  value       = var.nat_gateway_availability_mode == "zonal" ? local.nat_eip_allocations : []
 }
 
 output "az_private_subnets_map" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -75,22 +75,22 @@ output "private_network_acl_id" {
 
 output "nat_gateway_ids" {
   description = "IDs of the NAT Gateways created"
-  value       = var.nat_gateway_availability_mode == "regional" ? aws_nat_gateway.regional[*].id : aws_nat_gateway.default[*].id
+  value       = local.regional_nat_gateway_useful ? aws_nat_gateway.regional[*].id : aws_nat_gateway.default[*].id
 }
 
 output "nat_gateway_private_ips" {
   description = "Private IP addresses of the NAT Gateways (zonal mode only)"
-  value       = var.nat_gateway_availability_mode == "zonal" ? aws_nat_gateway.default[*].private_ip : []
+  value       = local.zonal_nat_gateway_useful ? aws_nat_gateway.default[*].private_ip : []
 }
 
 output "nat_gateway_route_table_id" {
   description = "ID of the automatically created route table for Regional NAT Gateway (regional mode only)"
-  value       = var.nat_gateway_availability_mode == "regional" && local.nat_gateway_enabled ? try(aws_nat_gateway.regional[0].route_table_id, null) : null
+  value       = local.regional_nat_gateway_useful ? try(aws_nat_gateway.regional[0].route_table_id, null) : null
 }
 
 output "nat_gateway_regional_addresses" {
   description = "Information about IP addresses and network interfaces for Regional NAT Gateway (regional mode only)"
-  value       = var.nat_gateway_availability_mode == "regional" && local.nat_gateway_enabled ? try(aws_nat_gateway.regional[0].regional_nat_gateway_address, []) : []
+  value       = local.regional_nat_gateway_useful ? try(aws_nat_gateway.regional[0].regional_nat_gateway_address, []) : []
 }
 
 output "nat_instance_ids" {
@@ -105,12 +105,12 @@ output "nat_instance_ami_id" {
 
 output "nat_ips" {
   description = "Elastic IP Addresses in use by NAT (zonal mode only; regional mode manages IPs automatically)"
-  value       = var.nat_gateway_availability_mode == "zonal" && local.need_nat_eip_data ? var.nat_elastic_ips : (var.nat_gateway_availability_mode == "zonal" ? aws_eip.default[*].public_ip : [])
+  value       = local.zonal_nat_gateway_useful && local.need_nat_eip_data ? var.nat_elastic_ips : (var.nat_gateway_availability_mode == "zonal" ? aws_eip.default[*].public_ip : [])
 }
 
 output "nat_eip_allocation_ids" {
   description = "Elastic IP allocations in use by NAT (zonal mode only; regional mode manages IPs automatically)"
-  value       = var.nat_gateway_availability_mode == "zonal" ? local.nat_eip_allocations : []
+  value       = local.zonal_nat_gateway_useful ? local.nat_eip_allocations : []
 }
 
 output "az_private_subnets_map" {

--- a/private.tf
+++ b/private.tf
@@ -48,7 +48,8 @@ resource "aws_subnet" "private" {
 }
 
 resource "aws_route_table" "private" {
-  # One route table per private subnet
+  # For regional NAT: one shared route table for all subnets
+  # For zonal NAT/NAT instance: one route table per private subnet
   count = local.private_route_table_count
 
   vpc_id = local.vpc_id
@@ -56,7 +57,11 @@ resource "aws_route_table" "private" {
   tags = merge(
     module.private_label.tags,
     {
-      "Name" = format("%s%s%s", module.private_label.id, local.delimiter, local.private_subnet_az_abbreviations[count.index])
+      "Name" = var.nat_gateway_availability_mode == "regional" ? (
+        module.private_label.id
+        ) : (
+        format("%s%s%s", module.private_label.id, local.delimiter, local.private_subnet_az_abbreviations[count.index])
+      )
     }
   )
 }

--- a/private.tf
+++ b/private.tf
@@ -57,7 +57,7 @@ resource "aws_route_table" "private" {
   tags = merge(
     module.private_label.tags,
     {
-      "Name" = var.nat_gateway_availability_mode == "regional" ? (
+      "Name" = local.regional_nat_gateway_useful ? (
         module.private_label.id
         ) : (
         format("%s%s%s", module.private_label.id, local.delimiter, local.private_subnet_az_abbreviations[count.index])

--- a/test/src/examples_regional_nat_gateway_test.go
+++ b/test/src/examples_regional_nat_gateway_test.go
@@ -1,0 +1,70 @@
+package test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	testStructure "github.com/gruntwork-io/terratest/modules/test-structure"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test the Terraform module in examples/regional-nat-gateway using Terratest.
+func TestExamplesRegionalNatGateway(t *testing.T) {
+	t.Parallel()
+	randID := strings.ToLower(random.UniqueId())
+	attributes := []string{randID}
+
+	rootFolder := "../../"
+	terraformFolderRelativeToRoot := "examples/regional-nat-gateway"
+	varFiles := []string{"fixtures.us-east-2.tfvars"}
+
+	tempTestFolder := testStructure.CopyTerraformFolderToTemp(t, rootFolder, terraformFolderRelativeToRoot)
+
+	terraformOptions := &terraform.Options{
+		// The path to where our Terraform code is located
+		TerraformDir: tempTestFolder,
+		Upgrade:      true,
+		// Variables to pass to our Terraform code using -var-file options
+		VarFiles: varFiles,
+		Vars: map[string]interface{}{
+			"attributes": attributes,
+		},
+	}
+
+	// At the end of the test, run `terraform destroy` to clean up any resources that were created
+	defer cleanup(t, terraformOptions, tempTestFolder)
+
+	// If Go runtime panics, run `terraform destroy` to clean up any resources that were created
+	defer func() {
+		if r := recover(); r != nil {
+			cleanup(t, terraformOptions, tempTestFolder)
+			panic(r) // Re-panic after cleanup
+		}
+	}()
+
+	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Run `terraform output` to get the value of an output variable
+	natGatewayIds := terraform.OutputList(t, terraformOptions, "nat_gateway_ids")
+
+	// Regional NAT Gateway should create exactly 1 NAT Gateway
+	assert.Equal(t, 1, len(natGatewayIds), "Regional NAT Gateway should create exactly 1 NAT Gateway")
+
+	// Verify that the NAT Gateway ID is not empty
+	assert.NotEmpty(t, natGatewayIds[0], "NAT Gateway ID should not be empty")
+
+	// Run `terraform output` to get the route table ID
+	routeTableId := terraform.Output(t, terraformOptions, "nat_gateway_route_table_id")
+
+	// Verify that the route table ID is not empty
+	assert.NotEmpty(t, routeTableId, "Regional NAT Gateway route table ID should not be empty")
+
+	// Run `terraform output` to get private subnet IDs
+	privateSubnetIds := terraform.OutputList(t, terraformOptions, "private_subnet_ids")
+
+	// Should have created private subnets (3 AZs specified in fixtures)
+	assert.Equal(t, 3, len(privateSubnetIds), "Should create 3 private subnets (one per AZ)")
+}

--- a/test/src/examples_regional_nat_gateway_test.go
+++ b/test/src/examples_regional_nat_gateway_test.go
@@ -67,4 +67,10 @@ func TestExamplesRegionalNatGateway(t *testing.T) {
 
 	// Should have created private subnets (3 AZs specified in fixtures)
 	assert.Equal(t, 3, len(privateSubnetIds), "Should create 3 private subnets (one per AZ)")
+
+	// Run `terraform output` to get private route table IDs
+	privateRouteTableIds := terraform.OutputList(t, terraformOptions, "private_route_table_ids")
+
+	// Should have created only one private route table
+	assert.Equal(t, 1, len(privateRouteTableIds), "Should create 1 private route table")
 }

--- a/variables.tf
+++ b/variables.tf
@@ -207,6 +207,23 @@ variable "nat_gateway_enabled" {
   default     = null
 }
 
+variable "nat_gateway_availability_mode" {
+  type        = string
+  description = <<-EOT
+    Availability mode for NAT Gateway. Valid values are `zonal` (default) and `regional`.
+    - `zonal`: Creates NAT Gateways in specific subnets (traditional behavior, supports both public and private connectivity)
+    - `regional`: Creates a single Regional NAT Gateway that automatically expands across AZs (only supports public connectivity, no public subnets required)
+    Regional NAT Gateways simplify architecture, enhance security (no public subnets needed), and provide automatic high availability.
+    Note: Regional NAT Gateways do not support private connectivity type. Use `zonal` mode for private NAT use cases.
+    EOT
+  default     = "zonal"
+  nullable    = false
+  validation {
+    condition     = contains(["zonal", "regional"], var.nat_gateway_availability_mode)
+    error_message = "The `nat_gateway_availability_mode` value must be either \"zonal\" or \"regional\"."
+  }
+}
+
 variable "nat_instance_enabled" {
   type        = bool
   description = <<-EOT


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

Implement support for AWS regional NAT gateways (`availability_mode = "regional"`).

I'm a bit unhappy with the size of the change, but apparently there was before no possibility to have only one private route table for multiple subnets. This, however, has the disadvantage that any updates (esp. when done for failover architectures) require updates to multiple routing tables.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

- no need to maintain separate routing tables per AZ
- no need for public subnets
- automatic scaling & management of EIPs


## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

[Terraform provider docs for `aws_nat_gatewas`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway#regional-nat-gateway-with-auto-mode)

closes #228 